### PR TITLE
ZCS-5095 Added google contacts importer.

### DIFF
--- a/src/java-test/com/zimbra/oauth/handlers/impl/GoogleContactsImportTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/GoogleContactsImportTest.java
@@ -1,0 +1,182 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra OAuth Social Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.oauth.handlers.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.zimbra.cs.account.DataSource;
+import com.zimbra.cs.mime.ParsedContact;
+import com.zimbra.oauth.handlers.impl.GoogleContactsImport.GoogleContactsUtil;
+import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleConstants;
+import com.zimbra.oauth.utilities.Configuration;
+
+/**
+ * Test class for {@link GoogleContactsImport}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ DataSource.class, GoogleContactsImport.class, GoogleContactsUtil.class })
+public class GoogleContactsImportTest {
+
+    /**
+     * Class under test.
+     */
+    protected GoogleContactsImport importer;
+
+    /**
+     * Access token for testing.
+     */
+    protected final String accessToken = "test-access-token";
+
+    /**
+     * Folder id for testing.
+     */
+    protected final int folderId = 2002;
+
+    /**
+     * Mock configuration handler property.
+     */
+    protected Configuration mockConfig = EasyMock.createMock(Configuration.class);
+
+    /**
+     * Mock data source for testing.
+     */
+    protected DataSource mockSource;
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockSource = EasyMock.createMock(DataSource.class);
+        importer = PowerMock.createPartialMock(GoogleContactsImport.class, new String[] { "refresh",
+            "buildContactsUrl", "getContactsRequest", "getExistingContacts", "parseNewContacts" },
+            mockSource);
+
+        Whitebox.setInternalState(importer, "config", mockConfig);
+
+        PowerMock.mockStatic(GoogleContactsUtil.class);
+    }
+
+    /**
+     * Test method for {@link GoogleContactsImport#importData}<br>
+     * Validates that the method fetches contacts and passes along to parse
+     * utilites.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testImportData() throws Exception {
+        expect(mockSource.getMailbox()).andReturn(null);
+        expect(mockSource.getFolderId()).andReturn(folderId);
+        expect(mockSource.getMultiAttr(anyObject())).andReturn(new String[] {});
+        // expect a fetch for existing contacts
+        expect(importer.getExistingContacts(anyObject(), eq(folderId)))
+            .andReturn(new HashSet<String>());
+        // expect a fetch for refresh token
+        expect(importer.refresh()).andReturn(accessToken);
+        // expect buildContactsUrl to be called
+        expect(importer.buildContactsUrl(anyObject(), anyObject(), anyObject()))
+            .andReturn(GoogleConstants.CONTACTS_URI);
+        final String jsonData = "{\"connections\":[{\"biographies\":[{\"contentType\":\"TEXT_PLAIN\",\"value\":\"lionnsss!\"}],\"emailAddresses\":[{\"value\":\"lionel@example.com\"}],\"etag\":\"fake-etag\",\"names\":[{\"displayName\":\"Lionel Ronkerts\",\"displayNameLastFirst\":\"Ronkerts, Lionel\",\"familyName\":\"Ronkerts\",\"givenName\":\"Lionel\",\"metadata\":{\"primary\":true,\"source\":{\"id\":\"fake-id\",\"type\":\"CONTACT\"}}}],\"organizations\":[{\"name\":\"Synacor\",\"title\":\"Tester\"}],\"photos\":[{\"default\":true,\"metadata\":{\"primary\":true,\"source\":{\"id\":\"fake-id\",\"type\":\"CONTACT\"}},\"url\":\"https://example.com/photo.jpg\"}],\"resourceName\":\"people/fake-people-id\"}],\"totalItems\":9,\"totalPeople\":9}";
+        final JsonNode jsonResponse = OAuth2Handler.mapper.readTree(jsonData);
+        expect(importer.getContactsRequest(anyObject(), anyObject())).andReturn(jsonResponse);
+        // expect parse new contacts to be called
+        importer.parseNewContacts(anyObject(Set.class), anyObject(JsonNode.class),
+            anyObject(List.class));
+        PowerMock.expectLastCall();
+
+        replay(mockConfig);
+        replay(mockSource);
+        replay(importer);
+
+        importer.importData(null, true);
+
+        verify(mockConfig);
+        verify(mockSource);
+        verify(importer);
+    }
+
+    /**
+     * Test method for {@link GoogleContactsImport#parseNewContacts}<br>
+     * Validates that the method adds a contact to the create list when it does
+     * not already exist.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testParseNewContacts() throws Exception {
+        final GoogleContactsImport localImporter = PowerMock
+            .createPartialMockForAllMethodsExcept(GoogleContactsImport.class, "parseNewContacts");
+        final Set<String> existingContacts = new HashSet<String>();
+        existingContacts.add("people/different-id");
+        final String jsonData = "{\"connections\":[{\"biographies\":[{\"contentType\":\"TEXT_PLAIN\",\"value\":\"lionnsss!\"}],\"emailAddresses\":[{\"value\":\"lionel@example.com\"}],\"etag\":\"fake-etag\",\"names\":[{\"displayName\":\"Lionel Ronkerts\",\"displayNameLastFirst\":\"Ronkerts, Lionel\",\"familyName\":\"Ronkerts\",\"givenName\":\"Lionel\",\"metadata\":{\"primary\":true,\"source\":{\"id\":\"fake-id\",\"type\":\"CONTACT\"}}}],\"organizations\":[{\"name\":\"Synacor\",\"title\":\"Tester\"}],\"photos\":[{\"default\":true,\"metadata\":{\"primary\":true,\"source\":{\"id\":\"fake-id\",\"type\":\"CONTACT\"}},\"url\":\"https://example.com/photo.jpg\"}],\"resourceName\":\"people/fake-people-id\"}],\"totalItems\":9,\"totalPeople\":9}";
+        final JsonNode jsonResponse = OAuth2Handler.mapper.readTree(jsonData);
+        final JsonNode jsonContacts = jsonResponse.get("connections");
+        final List<ParsedContact> createList = new ArrayList<ParsedContact>();
+
+        localImporter.parseNewContacts(existingContacts, jsonContacts, createList);
+
+        assertEquals(1, createList.size());
+    }
+
+    /**
+     * Test method for {@link GoogleContactsImport#parseNewContacts}<br>
+     * Validates that the method does not add a contact to the create list when
+     * it already exists.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testParseNewContactsWhenExists() throws Exception {
+        final GoogleContactsImport localImporter = PowerMock
+            .createPartialMockForAllMethodsExcept(GoogleContactsImport.class, "parseNewContacts");
+        final Set<String> existingContacts = new HashSet<String>();
+        existingContacts.add("people/fake-people-id");
+        final String jsonData = "{\"connections\":[{\"biographies\":[{\"contentType\":\"TEXT_PLAIN\",\"value\":\"lionnsss!\"}],\"emailAddresses\":[{\"value\":\"lionel@example.com\"}],\"etag\":\"fake-etag\",\"names\":[{\"displayName\":\"Lionel Ronkerts\",\"displayNameLastFirst\":\"Ronkerts, Lionel\",\"familyName\":\"Ronkerts\",\"givenName\":\"Lionel\",\"metadata\":{\"primary\":true,\"source\":{\"id\":\"fake-id\",\"type\":\"CONTACT\"}}}],\"organizations\":[{\"name\":\"Synacor\",\"title\":\"Tester\"}],\"photos\":[{\"default\":true,\"metadata\":{\"primary\":true,\"source\":{\"id\":\"fake-id\",\"type\":\"CONTACT\"}},\"url\":\"https://example.com/photo.jpg\"}],\"resourceName\":\"people/fake-people-id\"}],\"totalItems\":9,\"totalPeople\":9}";
+        final JsonNode jsonResponse = OAuth2Handler.mapper.readTree(jsonData);
+        final JsonNode jsonContacts = jsonResponse.get("connections");
+        final List<ParsedContact> createList = new ArrayList<ParsedContact>();
+
+        localImporter.parseNewContacts(existingContacts, jsonContacts, createList);
+
+        assertEquals(0, createList.size());
+    }
+
+}

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -528,7 +528,7 @@ public class GoogleContactsImport implements DataImport {
         public static final Map<String, String> PHONE_FIELDS_MAP = new HashMap<String, String>() {
 
             {
-                put(DEFAULT_TYPE, A_mobilePhone);
+                put(DEFAULT_TYPE, A_homePhone);
                 put("home", A_homePhone);
                 put("work", A_workPhone);
                 put("mobile", A_mobilePhone);
@@ -554,6 +554,7 @@ public class GoogleContactsImport implements DataImport {
         public static final Map<String, String> LINK_FIELDS_MAP = new HashMap<String, String>() {
 
             {
+                put(DEFAULT_TYPE, A_homeURL);
                 put("home", A_homeURL);
                 put("work", A_workURL);
                 put("other", A_otherURL);
@@ -622,6 +623,14 @@ public class GoogleContactsImport implements DataImport {
             }
         }
 
+        /**
+         * Parses a typed field object array into a Zimbra contact field.<br>
+         * The mappingField must specify a default type mapping.
+         *
+         * @param fieldArray The array of typed objects
+         * @param mappingFields The social service key -> zimbra key mapping. Must contain a default mapping.
+         * @param fields The parsed contact fields to update
+         */
         public static void parseTypedField(JsonNode fieldArray, Map<String, String> mappingFields,
             Map<String, String> fields) {
             int i = 1;
@@ -635,15 +644,16 @@ public class GoogleContactsImport implements DataImport {
                     }
                     // grab the value
                     final String value = fieldObject.get(VALUE).asText();
-                    // map by type to a Zimbra field
-                    if (mappingFields.containsKey(type)) {
-                        String fieldKey = mappingFields.get(type);
-                        // map numerically if we already have this key
-                        if (fields.containsKey(fieldKey)) {
-                            fieldKey = fieldKey.replace("1", "") + ++i;
-                        }
-                        fields.put(fieldKey, value);
+                    // map by type to a Zimbra field key
+                    String fieldKey = mappingFields.get(type);
+                    if (fieldKey == null) {
+                        fieldKey = mappingFields.get(DEFAULT_TYPE);
                     }
+                    // map numerically if we already have this key
+                    if (fields.containsKey(fieldKey)) {
+                        fieldKey = fieldKey.replace("1", "") + ++i;
+                    }
+                    fields.put(fieldKey, value);
                 }
             }
         }

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -358,10 +358,10 @@ public class GoogleContactsImport implements DataImport {
                     authorizationHeader);
                 // fetch contacts
                 final JsonNode jsonResponse = getContactsRequest(url, authorizationHeader);
-                respContent = jsonResponse.toString();
-                // log only at most verbose level, this contains privileged info
-                ZimbraLog.extensions.trace("Contacts sync response from Google %s", respContent);
                 if (jsonResponse != null && jsonResponse.isContainerNode()) {
+                    respContent = jsonResponse.toString();
+                    // log only at most verbose level, this contains privileged info
+                    ZimbraLog.extensions.trace("Contacts sync response from Google %s", respContent);
                     // parse contacts if any, and update the createList
                     if (jsonResponse.has("connections")
                         && jsonResponse.get("connections").isArray()) {
@@ -386,13 +386,12 @@ public class GoogleContactsImport implements DataImport {
                     }
                 } else {
                     ZimbraLog.extensions
-                        .debug("Did not find JSON response object. Response body: %s", respContent);
+                        .debug("Did not find JSON response object.");
                 }
             } while (pageToken != null);
         } catch (UnsupportedOperationException | IOException e) {
-            throw ServiceException.FAILURE(String.format(
-                "Data source sync failed. Failed to fetch contacts from  Google Contacts API. Response body: %s",
-                respContent), e);
+            throw ServiceException.FAILURE(
+                "Data source sync failed. Failed to fetch contacts from Google Contacts API.", e);
         }
 
         if (!createList.isEmpty()) {

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -102,6 +102,7 @@ import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleConstants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
+import com.zimbra.oauth.utilities.LdapConfiguration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
 import com.zimbra.oauth.utilities.OAuth2Utilities;
 import com.zimbra.oauth.utilities.OAuthDataSource;
@@ -125,7 +126,7 @@ public class GoogleContactsImport implements DataImport {
     /**
      * Configuration wrapper.
      */
-    private final Configuration config = Configuration.getDefaultConfiguration();
+    private Configuration config;
 
     /**
      * Constructor.
@@ -134,6 +135,12 @@ public class GoogleContactsImport implements DataImport {
      */
     public GoogleContactsImport(DataSource datasource) {
         mDataSource = datasource;
+        try {
+            config = LdapConfiguration.buildConfiguration(GoogleConstants.CLIENT_NAME);
+        } catch (final ServiceException e) {
+            ZimbraLog.extensions.info("Error loading configuration for google: %s", e.getMessage());
+            ZimbraLog.extensions.debug(e);
+        }
     }
 
     @Override

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -273,7 +273,7 @@ public class GoogleContactsImport implements DataImport {
         for (final JsonNode contactElement : jsonContacts) {
             try {
                 ZimbraLog.extensions
-                    .debug("Verifying if new contact for: " + jsonContacts.toString());
+                    .trace("Verifying if new contact for: %s", jsonContacts.toString());
                 String resourceName = null;
                 if (contactElement.has("resourceName")) {
                     resourceName = contactElement.get("resourceName").asText();
@@ -354,7 +354,7 @@ public class GoogleContactsImport implements DataImport {
                 pageToken = null;
                 // log only at most verbose level, this contains privileged info
                 ZimbraLog.extensions.trace(
-                    "Attempting to sync Google contacts. URL: %s. authorizationHeader: %", url,
+                    "Attempting to sync Google contacts. URL: %s. authorizationHeader: %s", url,
                     authorizationHeader);
                 // fetch contacts
                 final JsonNode jsonResponse = getContactsRequest(url, authorizationHeader);

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -1,0 +1,823 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra OAuth Social Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.oauth.handlers.impl;
+
+import static com.zimbra.common.mailbox.ContactConstants.A_anniversary;
+import static com.zimbra.common.mailbox.ContactConstants.A_birthday;
+import static com.zimbra.common.mailbox.ContactConstants.A_company;
+import static com.zimbra.common.mailbox.ContactConstants.A_department;
+import static com.zimbra.common.mailbox.ContactConstants.A_description;
+import static com.zimbra.common.mailbox.ContactConstants.A_email;
+import static com.zimbra.common.mailbox.ContactConstants.A_firstName;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeCity;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeCountry;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeFax;
+import static com.zimbra.common.mailbox.ContactConstants.A_homePhone;
+import static com.zimbra.common.mailbox.ContactConstants.A_homePhone2;
+import static com.zimbra.common.mailbox.ContactConstants.A_homePostalCode;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeState;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeStreet;
+import static com.zimbra.common.mailbox.ContactConstants.A_homeURL;
+import static com.zimbra.common.mailbox.ContactConstants.A_imAddress1;
+import static com.zimbra.common.mailbox.ContactConstants.A_image;
+import static com.zimbra.common.mailbox.ContactConstants.A_initials;
+import static com.zimbra.common.mailbox.ContactConstants.A_jobTitle;
+import static com.zimbra.common.mailbox.ContactConstants.A_lastName;
+import static com.zimbra.common.mailbox.ContactConstants.A_maidenName;
+import static com.zimbra.common.mailbox.ContactConstants.A_middleName;
+import static com.zimbra.common.mailbox.ContactConstants.A_mobilePhone;
+import static com.zimbra.common.mailbox.ContactConstants.A_namePrefix;
+import static com.zimbra.common.mailbox.ContactConstants.A_nameSuffix;
+import static com.zimbra.common.mailbox.ContactConstants.A_nickname;
+import static com.zimbra.common.mailbox.ContactConstants.A_notes;
+import static com.zimbra.common.mailbox.ContactConstants.A_office;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherCity;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherCountry;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherFax;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherPhone;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherPostalCode;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherState;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherStreet;
+import static com.zimbra.common.mailbox.ContactConstants.A_otherURL;
+import static com.zimbra.common.mailbox.ContactConstants.A_pager;
+import static com.zimbra.common.mailbox.ContactConstants.A_phoneticCompany;
+import static com.zimbra.common.mailbox.ContactConstants.A_workCity;
+import static com.zimbra.common.mailbox.ContactConstants.A_workCountry;
+import static com.zimbra.common.mailbox.ContactConstants.A_workEmail1;
+import static com.zimbra.common.mailbox.ContactConstants.A_workFax;
+import static com.zimbra.common.mailbox.ContactConstants.A_workMobile;
+import static com.zimbra.common.mailbox.ContactConstants.A_workPhone;
+import static com.zimbra.common.mailbox.ContactConstants.A_workPostalCode;
+import static com.zimbra.common.mailbox.ContactConstants.A_workState;
+import static com.zimbra.common.mailbox.ContactConstants.A_workStreet;
+import static com.zimbra.common.mailbox.ContactConstants.A_workURL;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.text.DateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.DataSource;
+import com.zimbra.cs.account.DataSource.DataImport;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Contact;
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.mime.ParsedContact;
+import com.zimbra.cs.service.mail.CreateContact;
+import com.zimbra.cs.service.util.ItemId;
+import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleConstants;
+import com.zimbra.oauth.models.OAuthInfo;
+import com.zimbra.oauth.utilities.Configuration;
+import com.zimbra.oauth.utilities.OAuth2Constants;
+import com.zimbra.oauth.utilities.OAuth2Utilities;
+import com.zimbra.oauth.utilities.OAuthDataSource;
+
+/**
+ * The GoogleContactsImport class.<br>
+ * Used to sync contacts from the Google social service.<br>
+ * Based on the original YahooContactsImport class by @author Greg Solovyev.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.oauth.handlers.impl
+ * @copyright Copyright © 2018
+ */
+public class GoogleContactsImport implements DataImport {
+
+    /**
+     * The datasource under import.
+     */
+    private final DataSource mDataSource;
+
+    /**
+     * Configuration wrapper.
+     */
+    private final Configuration config = Configuration.getDefaultConfiguration();
+
+    /**
+     * Constructor.
+     *
+     * @param datasource The datasource to set
+     */
+    public GoogleContactsImport(DataSource datasource) {
+        mDataSource = datasource;
+    }
+
+    @Override
+    public void test() throws ServiceException {
+        // list of contacts to create after parsing google responses
+        final List<ParsedContact> createList = new ArrayList<ParsedContact>();
+        // existing contacts from the datasource folder
+        final Set<String> existingContacts = new HashSet<String>();
+        // get a new access token and build the auth header
+        final String authorizationHeader = String.format("Bearer %s", refresh());
+        String respContent = "";
+        try {
+            // fetch contacts
+            final JsonNode jsonResponse = getContactsRequest(GoogleConstants.CONTACTS_URI,
+                authorizationHeader);
+            respContent = jsonResponse.toString();
+            if (jsonResponse != null && jsonResponse.isContainerNode()) {
+                // parse contacts if any, and update the createList
+                if (jsonResponse.has("connections") && jsonResponse.get("connections").isArray()) {
+                    final JsonNode jsonContacts = jsonResponse.get("connections");
+                    parseNewContacts(existingContacts, jsonContacts, createList);
+                } else {
+                    ZimbraLog.extensions.debug(
+                        "Did not find 'connections' element in JSON response object. Response body: %s",
+                        respContent);
+                }
+            } else {
+                ZimbraLog.extensions.debug("Did not find JSON response object. Response body: %s",
+                    respContent);
+            }
+        } catch (UnsupportedOperationException | IOException e) {
+            throw ServiceException.FAILURE(String.format(
+                "Data source test failed. Failed to fetch contacts from Google Contacts API for testing. Response body: %s",
+                respContent), e);
+        }
+        if (createList.isEmpty()) {
+            throw ServiceException.FAILURE(String.format(
+                "Data source test failed. Failed to fetch contacts from Google Contacts API for testing. Response body %s",
+                respContent), null);
+        }
+    }
+
+    /**
+     * Retrieves the Google user accessToken.
+     *
+     * @return accessToken A live access token
+     * @throws ServiceException If there are issues
+     */
+    protected String refresh() throws ServiceException {
+        final OAuthInfo oauthInfo = new OAuthInfo(new HashMap<String, String>());
+        final String refreshToken = OAuthDataSource.getRefreshToken(mDataSource);
+        final String clientId = config.getString(String
+            .format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE, GoogleConstants.CLIENT_NAME));
+        final String clientSecret = config.getString(String
+            .format(OAuth2Constants.LC_OAUTH_CLIENT_SECRET_TEMPLATE, GoogleConstants.CLIENT_NAME));
+        final String clientRedirectUri = config.getString(String.format(
+            OAuth2Constants.LC_OAUTH_CLIENT_REDIRECT_URI_TEMPLATE, GoogleConstants.CLIENT_NAME));
+
+        // set client specific properties
+        oauthInfo.setRefreshToken(refreshToken);
+        oauthInfo.setClientId(clientId);
+        oauthInfo.setClientSecret(clientSecret);
+        oauthInfo.setClientRedirectUri(clientRedirectUri);
+        oauthInfo.setTokenUrl(GoogleConstants.AUTHENTICATE_URI);
+
+        ZimbraLog.extensions.debug("Fetching access credentials for import.");
+        final JsonNode credentials = GoogleOAuth2Handler.getTokenRequest(oauthInfo,
+            OAuth2Utilities.encodeBasicHeader(clientId, clientSecret));
+
+        return credentials.get("access_token").asText();
+    }
+
+    /**
+     * Requests contacts for the given credentials.
+     *
+     * @param url The contacts url
+     * @param authorizationHeader The credentials header
+     * @return Json contacts response
+     * @throws ServiceException If there are issues retrieving the data
+     * @throws IOException If there are issues executing the request
+     */
+    protected JsonNode getContactsRequest(String url, String authorizationHeader)
+        throws ServiceException, IOException {
+        final GetMethod get = new GetMethod(url);
+        get.addRequestHeader(OAuth2Constants.HEADER_AUTHORIZATION, authorizationHeader);
+        ZimbraLog.extensions.debug("Fetching contacts for import.");
+        return OAuth2Handler.executeRequestForJson(get);
+    }
+
+    /**
+     * Retrieves a set of the contacts identifiers that exist in a specified
+     * folder.
+     *
+     * @param mailbox The mailbox
+     * @param folderId The folder
+     * @return Set of resourceNames for existing contacts
+     * @throws ServiceException If there are issues fetching the contacts
+     */
+    protected Set<String> getExistingContacts(Mailbox mailbox, int folderId)
+        throws ServiceException {
+        // fetch the list of existing contacts for the specified folder
+        List<Contact> contacts = null;
+        try {
+            contacts = mailbox.getContactList(null, folderId);
+        } catch (final ServiceException e) {
+            ZimbraLog.extensions.errorQuietly(
+                "Failed to retrieve existing contacts during Google contact sync.", e);
+            throw ServiceException
+                .FAILURE("Failed to retrieve existing contacts during Google contact sync.", e);
+        }
+
+        // create a resourceName set
+        final Set<String> contactsIdentifiers = new HashSet<String>();
+        for (final Contact contact : contacts) {
+            if (contact != null) {
+                final String resourceName = contact.get("resourceName");
+                if (resourceName != null) {
+                    contactsIdentifiers.add(resourceName);
+                }
+            }
+        }
+
+        return contactsIdentifiers;
+    }
+
+    /**
+     * Processes json contacts from google api into a ParsedContact, adding it
+     * to a create list if the contact does not already exist in the datasource
+     * folder - based on the resourceName property.
+     *
+     * @param existingContacts Contact resourceNames in the datasource folder
+     * @param jsonContacts Json contacts from google api
+     * @param createList List of contacts to create
+     */
+    protected void parseNewContacts(Set<String> existingContacts, JsonNode jsonContacts,
+        List<ParsedContact> createList) {
+        for (final JsonNode contactElement : jsonContacts) {
+            try {
+                ZimbraLog.extensions
+                    .debug("Verifying if new contact for: " + jsonContacts.toString());
+                String resourceName = null;
+                if (contactElement.has("resourceName")) {
+                    resourceName = contactElement.get("resourceName").asText();
+                }
+                // add to list of contacts to create only if it is new
+                if (resourceName == null || !existingContacts.contains(resourceName)) {
+                    // parse each contact into a Zimbra object
+                    final ParsedContact parsedContact = GoogleContactsUtil
+                        .parseContact(contactElement, mDataSource);
+                    createList.add(parsedContact);
+                }
+            } catch (final ServiceException e) {
+                ZimbraLog.extensions.errorQuietly("Unable to parse contact.", e);
+                // if we fail to parse one - continue with the rest
+            }
+        }
+    }
+
+    /**
+     * Builds the url with some dynamic contact request query params.
+     *
+     * @param url The contact url
+     * @param syncToken The token to use when fetching changes
+     * @param pageToken The token to identify which page we're fetching
+     * @return Query params to add to the url
+     * @throws UnsupportedEncodingException If there are issues building
+     * @throws ServiceException
+     */
+    protected String buildContactsUrl(String url, String syncToken, String pageToken)
+        throws ServiceException {
+        try {
+            final URIBuilder builder = new URIBuilder(url);
+            if (!StringUtils.isEmpty(syncToken)) {
+                // add syncToken if repeated fetch
+                builder.addParameter("syncToken", syncToken);
+            } else {
+                // request a syncToken if first fetch
+                builder.addParameter("requestSyncToken", "true");
+            }
+
+            // always set page size
+            builder.addParameter("pageSize", GoogleConstants.CONTACTS_PAGE_SIZE);
+
+            if (pageToken != null) {
+                // set the page token if it exists
+                builder.addParameter("pageToken", pageToken);
+            }
+            return builder.build().toString();
+        } catch (final URISyntaxException e) {
+            throw ServiceException.FAILURE("Failed to generate contacts fetch url.", e);
+        }
+    }
+
+    @Override
+    public void importData(List<Integer> folderIds, boolean fullSync) throws ServiceException {
+        final Mailbox mailbox = mDataSource.getMailbox();
+        final int folderId = mDataSource.getFolderId();
+        // list of contacts to create after parsing google responses
+        final List<ParsedContact> createList = new ArrayList<ParsedContact>();
+        // existing contacts from the datasource folder
+        final Set<String> existingContacts = getExistingContacts(mailbox, folderId);
+        // get a new access token and build the auth header
+        final String authorizationHeader = String.format("Bearer %s", refresh());
+        // fetch the syncToken
+        final String[] attrs = mDataSource.getMultiAttr(Provisioning.A_zimbraDataSourceAttribute);
+        String syncToken = null;
+        if (attrs.length > 0) {
+            syncToken = attrs[0];
+        }
+        String respContent = "";
+        String pageToken = null;
+        try {
+            // loop to handle pagination
+            do {
+                // build contacts url, query params with syncToken and current pageToken
+                final String url = buildContactsUrl(GoogleConstants.CONTACTS_URI, syncToken, pageToken);
+                // always set an empty page token during pagination
+                pageToken = null;
+                // log only at most verbose level, this contains privileged info
+                ZimbraLog.extensions.trace(
+                    "Attempting to sync Google contacts. URL: %s. authorizationHeader: %", url,
+                    authorizationHeader);
+                // fetch contacts
+                final JsonNode jsonResponse = getContactsRequest(url, authorizationHeader);
+                respContent = jsonResponse.toString();
+                // log only at most verbose level, this contains privileged info
+                ZimbraLog.extensions.trace("Contacts sync response from Google %s", respContent);
+                if (jsonResponse != null && jsonResponse.isContainerNode()) {
+                    // parse contacts if any, and update the createList
+                    if (jsonResponse.has("connections")
+                        && jsonResponse.get("connections").isArray()) {
+                        final JsonNode jsonContacts = jsonResponse.get("connections");
+                        parseNewContacts(existingContacts, jsonContacts, createList);
+                    } else {
+                        ZimbraLog.extensions.debug(
+                            "Did not find 'connections' element in JSON response object. Response body: %s",
+                            respContent);
+                    }
+                    // update the sync token if available
+                    if (jsonResponse.has("nextSyncToken")) {
+                        syncToken = jsonResponse.get("nextSyncToken").asText();
+                        final Map<String, Object> dsAttrs = new HashMap<String, Object>();
+                        dsAttrs.put(Provisioning.A_zimbraDataSourceAttribute, syncToken);
+                        Provisioning.getInstance().modifyDataSource(mDataSource.getAccount(),
+                            mDataSource.getId(), dsAttrs);
+                    }
+                    // check for next page
+                    if (jsonResponse.has("nextPageToken")) {
+                        pageToken = jsonResponse.get("nextPageToken").asText();
+                    }
+                } else {
+                    ZimbraLog.extensions
+                        .debug("Did not find JSON response object. Response body: %s", respContent);
+                }
+            } while (pageToken != null);
+        } catch (UnsupportedOperationException | IOException e) {
+            throw ServiceException.FAILURE(String.format(
+                "Data source sync failed. Failed to fetch contacts from  Google Contacts API. Response body: %s",
+                respContent), e);
+        }
+
+        if (!createList.isEmpty()) {
+            // create the contacts we determined need to be added
+            ZimbraLog.extensions.debug("Creating contacts from parsed list.");
+            CreateContact.createContacts(null, mailbox, new ItemId(mailbox, folderId), createList,
+                null);
+        }
+    }
+
+    /**
+     * The GoogleContactsUtil class.<br>
+     * Used to parse contacts from the Google social service.
+     *
+     * @author Zimbra API Team
+     * @package com.zimbra.oauth.handlers.impl
+     * @copyright Copyright © 2018
+     */
+    @SuppressWarnings("serial")
+    public static class GoogleContactsUtil {
+
+        static enum GContactFieldType {
+            resourceName,
+            nicknames,
+            emailAddresses,
+            phoneNumbers,
+            organizations,
+            biographies,
+            urls,
+            names,
+            addresses,
+            birthdays,
+            events,
+            photos,
+            userDefined,
+            skills,
+            interests,
+            braggingRights,
+            relationshipInterests,
+            relationshipStatuses,
+            occupations,
+            taglines
+        }
+
+        // parts of contact JSON object
+        public static final String KEY = "key";
+        public static final String VALUE = "value";
+        public static final String TYPE = "type";
+        public static final String DATE = "date";
+        public static final String FIELDS = "fields";
+
+        public static final String DEFAULT_TYPE = "DEFAULT_TYPE";
+
+        // google name field value parts
+        public static final String GIVENNAME = "givenName";
+        public static final String MIDDLE = "middleName";
+        public static final String FAMILYNAME = "familyName";
+        public static final String PREFIX = "honorificPrefix";
+        public static final String SUFFIX = "honorificSuffix";
+
+        public static final Map<String, String> NAME_FIELDS_MAP = new HashMap<String, String>() {
+
+            {
+                put(GIVENNAME, A_firstName);
+                put(MIDDLE, A_middleName);
+                put(FAMILYNAME, A_lastName);
+                put(PREFIX, A_namePrefix);
+                put(SUFFIX, A_nameSuffix);
+            }
+        };
+
+        // google nickname types
+        public static final String MAIDEN_NAME = "MAIDEN_NAME";
+        public static final String INITIALS = "INITIALS";
+        public static final String GPLUS = "GPLUS";
+
+        public static final Map<String, String> NICKNAME_FIELDS_MAP = new HashMap<String, String>() {
+
+            {
+                put(DEFAULT_TYPE, A_nickname);
+                put(MAIDEN_NAME, A_maidenName);
+                put(INITIALS, A_initials);
+                put(GPLUS, A_imAddress1);
+            }
+        };
+
+        // google address field value parts
+        public static final String STREET = "streetAddress";
+        public static final String EXTENDED_ADDRESS = "extendedAddress";
+        public static final String CITY = "city";
+        public static final String STATE = "region";
+        public static final String POSTALCODE = "postalCode";
+        public static final String COUNTRY = "country";
+        public static final String COUNTRYCODE = "countryCode";
+        public static final Map<String, List<String>> WORK_ADDRESS_FIELDS_MAP = new HashMap<String, List<String>>() {
+
+            {
+                put(A_workStreet, Arrays.asList(STREET, EXTENDED_ADDRESS));
+                put(A_workCity, Arrays.asList(CITY));
+                put(A_workState, Arrays.asList(STATE));
+                put(A_workPostalCode, Arrays.asList(POSTALCODE));
+                put(A_workCountry, Arrays.asList(COUNTRY, COUNTRYCODE));
+            }
+        };
+        public static final Map<String, List<String>> HOME_ADDRESS_FIELDS_MAP = new HashMap<String, List<String>>() {
+
+            {
+                put(A_homeStreet, Arrays.asList(STREET, EXTENDED_ADDRESS));
+                put(A_homeCity, Arrays.asList(CITY));
+                put(A_homeState, Arrays.asList(STATE));
+                put(A_homePostalCode, Arrays.asList(POSTALCODE));
+                put(A_homeCountry, Arrays.asList(COUNTRY, COUNTRYCODE));
+            }
+        };
+        public static final Map<String, List<String>> OTHER_ADDRESS_FIELDS_MAP = new HashMap<String, List<String>>() {
+
+            {
+                put(A_otherStreet, Arrays.asList(STREET, EXTENDED_ADDRESS));
+                put(A_otherCity, Arrays.asList(CITY));
+                put(A_otherState, Arrays.asList(STATE));
+                put(A_otherPostalCode, Arrays.asList(POSTALCODE));
+                put(A_otherCountry, Arrays.asList(COUNTRY, COUNTRYCODE));
+            }
+        };
+        // google date field value parts
+        public static final String DAY = "day";
+        public static final String MONTH = "month";
+        public static final String YEAR = "year";
+        public static final Map<String, String> DATE_FIELDS_MAP = new HashMap<String, String>() {
+
+            {
+                put("birthday", A_birthday);
+                put("anniversary", A_anniversary);
+            }
+        };
+        public static final Map<String, String> PHONE_FIELDS_MAP = new HashMap<String, String>() {
+
+            {
+                put(DEFAULT_TYPE, A_mobilePhone);
+                put("home", A_homePhone);
+                put("work", A_workPhone);
+                put("mobile", A_mobilePhone);
+                put("homeFax", A_homeFax);
+                put("workFax", A_workFax);
+                put("otherFax", A_otherFax);
+                put("pager", A_pager);
+                put("workMobile", A_workMobile);
+                put("workPager", A_pager);
+                put("main", A_mobilePhone);
+                put("googleVoice", A_homePhone2);
+                put("other", A_otherPhone);
+            }
+        };
+        public static final Map<String, String> EMAIL_FIELDS_MAP = new HashMap<String, String>() {
+
+            {
+                put(DEFAULT_TYPE, A_email);
+                put("home", A_email);
+                put("work", A_workEmail1);
+            }
+        };
+        public static final Map<String, String> LINK_FIELDS_MAP = new HashMap<String, String>() {
+
+            {
+                put("home", A_homeURL);
+                put("work", A_workURL);
+                put("other", A_otherURL);
+            }
+        };
+        public static final String IMAGE_URL = "url";
+
+        public static final Map<String, String> ORGANIZATIONS_FIELDS_MAP = new HashMap<String, String>() {
+
+            {
+                put("name", A_company);
+                put("phoneticName", A_phoneticCompany);
+                put("title", A_jobTitle);
+                put("jobDescription", A_description);
+                put("department", A_department);
+                put("location", A_office);
+            }
+        };
+
+        public static void parseKeyValueField(JsonNode fieldArray, Map<String, String> fields) {
+            for (final JsonNode fieldObject : fieldArray) {
+                if (fieldObject.has(KEY) && fieldObject.has(VALUE)) {
+                    final JsonNode key = fieldObject.get(KEY);
+                    final JsonNode value = fieldObject.get(VALUE);
+                    if (key.isTextual() && value.isTextual()) {
+                        fields.put(key.asText(), value.asText());
+                    }
+                }
+            }
+        }
+
+        public static void parseSimpleField(JsonNode fieldArray, String zimbraFieldKey,
+            Map<String, String> fields) {
+            int i = 1;
+            for (final JsonNode fieldObject : fieldArray) {
+                if (fieldObject.has(VALUE)) {
+                    // grab the value
+                    final String value = fieldObject.get(VALUE).asText();
+                    // map to Zimbra field numerically if we already have a
+                    // value set
+                    if (fields.containsKey(zimbraFieldKey)) {
+                        zimbraFieldKey = zimbraFieldKey.replace("1", "") + ++i;
+                    }
+                    fields.put(zimbraFieldKey, value);
+                }
+            }
+        }
+
+        public static void parseMappingField(JsonNode fieldArray, Map<String, String> mappingFields,
+            Map<String, String> fields) {
+            int i = 1;
+            for (final JsonNode fieldObject : fieldArray) {
+                for (final Entry<String, String> mapping : mappingFields.entrySet()) {
+                    if (fieldObject.has(mapping.getKey())) {
+                        // grab the value
+                        final String value = fieldObject.get(mapping.getKey()).asText();
+                        String fieldKey = mapping.getValue();
+                        // map to Zimbra field numerically if we already have a
+                        // value set
+                        if (fields.containsKey(fieldKey)) {
+                            fieldKey = fieldKey.replace("1", "") + ++i;
+                        }
+                        fields.put(fieldKey, value);
+                    }
+                }
+            }
+        }
+
+        public static void parseTypedField(JsonNode fieldArray, Map<String, String> mappingFields,
+            Map<String, String> fields) {
+            int i = 1;
+            for (final JsonNode fieldObject : fieldArray) {
+                if (fieldObject.has(VALUE)) {
+                    // determine the type of this element so we can map, default
+                    // otherwise
+                    String type = DEFAULT_TYPE;
+                    if (fieldObject.has(TYPE)) {
+                        type = fieldObject.get(TYPE).asText();
+                    }
+                    // grab the value
+                    final String value = fieldObject.get(VALUE).asText();
+                    // map by type to a Zimbra field
+                    if (mappingFields.containsKey(type)) {
+                        String fieldKey = mappingFields.get(type);
+                        // map numerically if we already have this key
+                        if (fields.containsKey(fieldKey)) {
+                            fieldKey = fieldKey.replace("1", "") + ++i;
+                        }
+                        fields.put(fieldKey, value);
+                    }
+                }
+            }
+        }
+
+        public static void parseDateField(JsonNode fieldArray, Locale locale,
+            Map<String, String> fields) {
+            for (final JsonNode fieldObject : fieldArray) {
+                String zContactFieldName = null;
+                if (fieldObject.has(DATE)) {
+                    String type = "birthday";
+                    if (fieldObject.has(TYPE)) {
+                        type = fieldObject.get(TYPE).asText().toLowerCase();
+                    }
+                    zContactFieldName = StringUtils.defaultIfEmpty(DATE_FIELDS_MAP.get(type), type);
+                    final JsonNode valueObject = fieldObject.get(DATE);
+                    if (valueObject.isObject()) {
+                        Integer year = null;
+                        Integer month = null;
+                        Integer day = null;
+                        if (valueObject.has(YEAR)) {
+                            year = valueObject.get(YEAR).asInt();
+                        }
+                        if (valueObject.has(MONTH)) {
+                            month = valueObject.get(MONTH).asInt();
+                        }
+                        if (valueObject.has(DAY)) {
+                            day = valueObject.get(DAY).asInt();
+                        }
+                        if (day == null || month == null) {
+                            return;
+                        }
+
+                        final Calendar cal = Calendar.getInstance(locale);
+                        if (year != null) {
+                            cal.set(Calendar.YEAR, year);
+                        }
+                        if (month != null) {
+                            cal.set(Calendar.MONTH, month - 1);
+                        }
+                        if (day != null) {
+                            cal.set(Calendar.DAY_OF_MONTH, day);
+                        }
+                        final DateFormat df = DateFormat.getDateInstance(DateFormat.SHORT, locale);
+                        final String dateString = df.format(cal.getTime());
+                        fields.put(zContactFieldName, dateString);
+                    }
+                }
+            }
+        }
+
+        public static void parseImageField(JsonNode fieldArray, String key,
+            Map<String, String> fields) {
+            for (final JsonNode fieldObject : fieldArray) {
+                if (fieldObject.has(IMAGE_URL)) {
+                    final String value = fieldObject.get(IMAGE_URL).asText();
+                    if (!StringUtils.isEmpty(value)) {
+                        fields.put(key, value);
+                    }
+                }
+            }
+        }
+
+        public static void parseAddressField(JsonNode fieldArray, Map<String, String> fields) {
+            for (final JsonNode fieldObject : fieldArray) {
+                if (fieldObject.isObject() && fieldObject.has(TYPE)) {
+                    final String type = fieldObject.get(TYPE).asText();
+                    Map<String, List<String>> targetMap = HOME_ADDRESS_FIELDS_MAP;
+                    if (type != null) {
+                        if (type.equalsIgnoreCase("work")) {
+                            targetMap = WORK_ADDRESS_FIELDS_MAP;
+                        } else if (type.equalsIgnoreCase("home")) {
+                            targetMap = HOME_ADDRESS_FIELDS_MAP;
+                        } else {
+                            targetMap = OTHER_ADDRESS_FIELDS_MAP;
+                        }
+                    }
+                    for (final String key : targetMap.keySet()) {
+                        parseValuePart(fieldObject, targetMap.get(key), key, fields);
+                    }
+                }
+            }
+        }
+
+        public static void parseValuePart(JsonNode valueObject, List<String> partNames,
+            String fieldName, Map<String, String> fields) {
+            for (final String partName : partNames) {
+                if (valueObject.has(partName)) {
+                    final JsonNode tmp = valueObject.get(partName);
+                    if (tmp != null) {
+                        final String szValue = tmp.asText();
+                        if (szValue != null && !szValue.isEmpty()) {
+                            fields.put(fieldName, szValue);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        public static ParsedContact parseContact(JsonNode jsonContact, DataSource ds)
+            throws ServiceException {
+            final Map<String, String> contactFields = new HashMap<String, String>();
+            for (final GContactFieldType type : GContactFieldType.values()) {
+                if (type != null) {
+                    if (jsonContact.has(type.name())) {
+                        final JsonNode fieldArray = jsonContact.get(type.name());
+                        switch (type) {
+                        case resourceName:
+                            if (fieldArray.isTextual()) {
+                                contactFields.put(GContactFieldType.resourceName.name(),
+                                    fieldArray.asText());
+                            }
+                            break;
+                        case addresses:
+                            parseAddressField(fieldArray, contactFields);
+                            break;
+                        case emailAddresses:
+                            parseTypedField(fieldArray, EMAIL_FIELDS_MAP, contactFields);
+                            break;
+                        case phoneNumbers:
+                            parseTypedField(fieldArray, PHONE_FIELDS_MAP, contactFields);
+                            break;
+                        case birthdays:
+                        case events:
+                            Locale locale = null;
+                            if (ds != null) {
+                                locale = ds.getAccount().getLocale();
+                            }
+                            if (locale == null) {
+                                try {
+                                    locale = Provisioning.getInstance().getConfig().getLocale();
+                                } catch (final Exception e) {
+                                    ZimbraLog.extensions
+                                        .warn("Failed to get locale while parsing a contact");
+                                }
+                            }
+                            if (locale == null) {
+                                locale = Locale.US;
+                            }
+                            parseDateField(fieldArray, locale, contactFields);
+                            break;
+                        case names:
+                            parseMappingField(fieldArray, NAME_FIELDS_MAP, contactFields);
+                            break;
+                        case nicknames:
+                            parseTypedField(fieldArray, NICKNAME_FIELDS_MAP, contactFields);
+                            break;
+                        case biographies:
+                            parseSimpleField(fieldArray, A_notes, contactFields);
+                            break;
+                        case organizations:
+                            parseMappingField(fieldArray, ORGANIZATIONS_FIELDS_MAP, contactFields);
+                            break;
+                        case urls:
+                            parseTypedField(fieldArray, LINK_FIELDS_MAP, contactFields);
+                            break;
+                        case photos:
+                            parseImageField(fieldArray, A_image, contactFields);
+                            break;
+                        case userDefined:
+                            parseKeyValueField(fieldArray, contactFields);
+                            break;
+                        default:
+                            parseSimpleField(fieldArray, type.name(), contactFields);
+                            break;
+                        }
+                    }
+                }
+            }
+            if (!contactFields.isEmpty()) {
+                return new ParsedContact(contactFields);
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
@@ -19,6 +19,7 @@ package com.zimbra.oauth.handlers.impl;
 import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.zimbra.client.ZFolder.View;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.oauth.handlers.IOAuth2Handler;
@@ -86,6 +87,16 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
         protected static final String AUTHENTICATE_URI = "https://www.googleapis.com/oauth2/v4/token";
 
         /**
+         * The contacts endpoint for Google.
+         */
+        protected static final String CONTACTS_URI = "https://people.googleapis.com/v1/people/me/connections?personFields=names,emailAddresses,organizations,phoneNumbers,addresses,events,birthdays,biographies,nicknames,urls,photos,userDefined,skills,interests,braggingRights,relationshipInterests,relationshipStatuses,occupations,taglines";
+
+        /**
+         * The contacts pagination size for Google.
+         */
+        protected static final String CONTACTS_PAGE_SIZE = "100";
+
+        /**
          * The scope required for Google.
          */
         protected static final String REQUIRED_SCOPES = "email";
@@ -120,6 +131,8 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
         authenticateUri = GoogleConstants.AUTHENTICATE_URI;
         authorizeUri = buildAuthorizeUri(GoogleConstants.AUTHORIZE_URI_TEMPLATE);
         relayKey = GoogleConstants.RELAY_KEY;
+        dataSource.addImportClass(View.contact.name(),
+            GoogleContactsImport.class.getCanonicalName());
 
     }
 


### PR DESCRIPTION
* Added support for Google contact import. Follows structure of the Yahoo version.
* As requested in the discussion chain:
  * Only creates new contacts
    * "New" is defined as a contact which does not have an associated contact (determined by `resourceName` property added to the contact) in the datasource folder at the time of the sync - seeking opinions on this determination method
  * Does not delete/modify existing contacts
* See JIRA ticket for omitted properties (ageRanges, gender, relations, etc). Open for discussion if any of these are necessary immediately.