### PR TITLE
ZCS-5109 Add logging and fix parsing of api scope attr

### DIFF
--- a/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
@@ -202,6 +202,7 @@ public abstract class OAuth2Handler {
         JsonNode json = null;
         try {
             json = executeRequestForJson(request);
+            ZimbraLog.extensions.trace("Response for autn token request:%s", json);
         } catch (final IOException e) {
             ZimbraLog.extensions
                 .errorQuietly("There was an issue acquiring the authorization token.", e);

--- a/src/java/com/zimbra/oauth/utilities/LdapConfiguration.java
+++ b/src/java/com/zimbra/oauth/utilities/LdapConfiguration.java
@@ -93,7 +93,7 @@ public class LdapConfiguration extends Configuration {
                     && registeredOAuth2RedirectUrls.length != 0) {
                     // {redirectURI}:{consumer-app-name} (the redirect uri can contain ":")
                     for (String consumer : registeredOAuth2RedirectUrls) {
-                        int index = consumer.lastIndexOf(":");
+                        int index = consumer.lastIndexOf(':');
                         if (index != -1) {
                             String temp = consumer.substring(index+1);
                             if (temp.equals(appName)) {
@@ -108,11 +108,14 @@ public class LdapConfiguration extends Configuration {
                     .getMultiAttr(Provisioning.A_zimbraOAuthConsumerAPIScope);
 
                 if (registeredOAuth2APIScope != null && registeredOAuth2APIScope.length != 0) {
-                    for (String consumer : registeredOAuth2APIScope) {
-                        String s[] = consumer.split(":");
-                        if (s.length == 2 && s[1].equals(appName)) {
-                            value = s[0];
-                            break;
+                    for (String scope : registeredOAuth2APIScope) {
+                        int index = scope.lastIndexOf(':');
+                        if (index != -1) {
+                            String temp = scope.substring(index+1);
+                            if (temp.equals(appName)) {
+                                value = scope.substring(0, index);
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The API  scope attribute can also be a URI(so can contain":", hence modified the parsing of zimbraOAuthConsumerAPIScope.

Added logging for improving debugging