### PR TITLE
ZCS-5095 Added code to throw exception for error resp

### DIFF
--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -378,6 +378,12 @@ public class GoogleContactsImport implements DataImport {
                         ZimbraLog.extensions.debug(
                             "Did not find 'connections' element in JSON response object. Response body: %s",
                             respContent);
+                        if (jsonResponse.has("error")) {
+                            throw ServiceException.FAILURE(
+                                String.format("Data source sync failed. Failed to fetch contacts"
+                                    + " from Google Contacts API. the error was:%s", jsonResponse.findValue("error")),
+                                    new Exception("operation failed")) ;
+                        }
                     }
                     // update the sync token if available
                     if (jsonResponse.has("nextSyncToken")) {


### PR DESCRIPTION
When importing contacts if the scope is not defined correctly or the library is not added to the credentials, the import will return error. 
Added code to throw an exception if the import fails and return error.

Verified by removing the API scope  attribute and importing contacts, the import failed and and exception was recorded in the logs.
