### PR TITLE
Zcs 5201 Profile image fetch on contact import

### DIFF
--- a/src/java-test/com/zimbra/oauth/handlers/impl/GoogleOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/GoogleOAuth2HandlerTest.java
@@ -38,6 +38,7 @@ import org.powermock.reflect.Whitebox;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.client.ZMailbox;
+import com.zimbra.cs.account.Account;
 import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleConstants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
@@ -95,15 +96,16 @@ public class GoogleOAuth2HandlerTest {
     @Before
     public void setUp() throws Exception {
         handler = PowerMock.createPartialMockForAllMethodsExcept(GoogleOAuth2Handler.class,
-            "authorize", "authenticate", "buildAuthorizeUri");
+            "authorize", "authenticate");
+        Whitebox.setInternalState(handler, "config", mockConfig);
         Whitebox.setInternalState(handler, "relayKey", GoogleConstants.RELAY_KEY);
-        Whitebox.setInternalState(handler, "clientRedirectUri", clientRedirectUri);
-        Whitebox.setInternalState(handler, "clientId", clientId);
-        Whitebox.setInternalState(handler, "clientSecret", clientSecret);
         Whitebox.setInternalState(handler, "authenticateUri", GoogleConstants.AUTHENTICATE_URI);
-        Whitebox.setInternalState(handler, "scope", GoogleConstants.REQUIRED_SCOPES);
+        Whitebox.setInternalState(handler, "authorizeUriTemplate",
+            GoogleConstants.AUTHORIZE_URI_TEMPLATE);
+        Whitebox.setInternalState(handler, "requiredScopes", GoogleConstants.REQUIRED_SCOPES);
+        Whitebox.setInternalState(handler, "scopeDelimiter", GoogleConstants.SCOPE_DELIMITER);
+        Whitebox.setInternalState(handler, "client", GoogleConstants.CLIENT_NAME);
         Whitebox.setInternalState(handler, "dataSource", mockDataSource);
-        Whitebox.setInternalState(handler, "authorizeUri", handler.buildAuthorizeUri(GoogleConstants.AUTHORIZE_URI_TEMPLATE));
     }
 
     /**
@@ -120,10 +122,6 @@ public class GoogleOAuth2HandlerTest {
             OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE))
                 .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE);
         expect(mockConfig.getString(OAuth2Constants.LC_ZIMBRA_SERVER_HOSTNAME)).andReturn(hostname);
-        expect(mockConfig.getString(String.format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE, GoogleConstants.CLIENT_NAME))).andReturn(clientId);
-        expect(mockConfig.getString(String.format(OAuth2Constants.LC_OAUTH_CLIENT_SECRET_TEMPLATE, GoogleConstants.CLIENT_NAME))).andReturn(clientSecret);
-        expect(mockConfig.getString(String.format(OAuth2Constants.LC_OAUTH_CLIENT_REDIRECT_URI_TEMPLATE, GoogleConstants.CLIENT_NAME))).andReturn(clientRedirectUri);
-        expect(mockConfig.getString(String.format(OAuth2Constants.LC_OAUTH_SCOPE_TEMPLATE, GoogleConstants.CLIENT_NAME))).andReturn(null);
         PowerMock.mockStatic(OAuthDataSource.class);
         expect(OAuthDataSource.createDataSource(GoogleConstants.CLIENT_NAME,
             GoogleConstants.HOST_GOOGLE)).andReturn(mockDataSource);
@@ -147,8 +145,19 @@ public class GoogleOAuth2HandlerTest {
     @Test
     public void testAuthorize() throws Exception {
         final String encodedUri = URLEncoder.encode(clientRedirectUri, OAuth2Constants.ENCODING);
+        final String expectedAuthorize = String.format(GoogleConstants.AUTHORIZE_URI_TEMPLATE,
+            clientId, encodedUri, "code", GoogleConstants.REQUIRED_SCOPES);
 
-        final String authorizeLocation = handler.authorize(null);
+        // expect buildAuthorize call
+        expect(handler.buildAuthorizeUri(GoogleConstants.AUTHORIZE_URI_TEMPLATE, null))
+            .andReturn(expectedAuthorize);
+
+        replay(handler);
+
+        final String authorizeLocation = handler.authorize(null, null);
+
+        // verify build was called
+        verify(handler);
 
         assertNotNull(authorizeLocation);
         assertEquals(String.format(GoogleConstants.AUTHORIZE_URI_TEMPLATE, clientId, encodedUri,
@@ -157,7 +166,7 @@ public class GoogleOAuth2HandlerTest {
 
     /**
      * Test method for {@link GoogleOAuth2Handler#authenticate}<br>
-     * Validates that the authenticate method calls update datasource.
+     * Validates that the authenticate method calls sync datasource.
      *
      * @throws Exception If there are issues testing
      */
@@ -173,14 +182,31 @@ public class GoogleOAuth2HandlerTest {
 
         PowerMock.mockStatic(OAuth2Handler.class);
 
+        expect(mockOAuthInfo.getAccount()).andReturn(null);
+        expect(
+            mockConfig.getString(
+                matches(String.format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE,
+                    GoogleConstants.CLIENT_NAME)),
+                matches(GoogleConstants.CLIENT_NAME), anyObject())).andReturn(clientId);
+        expect(
+            mockConfig.getString(
+                matches(String.format(OAuth2Constants.LC_OAUTH_CLIENT_SECRET_TEMPLATE,
+                    GoogleConstants.CLIENT_NAME)),
+                matches(GoogleConstants.CLIENT_NAME), anyObject())).andReturn(clientSecret);
+        expect(
+            mockConfig.getString(
+                matches(String.format(OAuth2Constants.LC_OAUTH_CLIENT_REDIRECT_URI_TEMPLATE,
+                    GoogleConstants.CLIENT_NAME)),
+                matches(GoogleConstants.CLIENT_NAME), anyObject())).andReturn(clientRedirectUri);
         expect(handler.getZimbraMailbox(anyObject(String.class))).andReturn(mockZMailbox);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
-        .andReturn(mockCredentials);
+            .andReturn(mockCredentials);
         handler.validateTokenResponse(anyObject());
         EasyMock.expectLastCall().once();
         expect(mockCredentials.get("refresh_token")).andReturn(mockCredentialsRToken);
         expect(mockCredentialsRToken.asText()).andReturn(refreshToken);
-        expect(handler.getPrimaryEmail(anyObject(JsonNode.class))).andReturn(username);
+        expect(handler.getPrimaryEmail(anyObject(JsonNode.class), anyObject(Account.class)))
+            .andReturn(username);
 
         mockOAuthInfo.setClientId(matches(clientId));
         EasyMock.expectLastCall().once();
@@ -201,6 +227,7 @@ public class GoogleOAuth2HandlerTest {
         replay(handler);
         PowerMock.replay(OAuth2Handler.class);
         replay(mockOAuthInfo);
+        replay(mockConfig);
         replay(mockCredentials);
         replay(mockCredentialsRToken);
         replay(mockDataSource);
@@ -210,6 +237,7 @@ public class GoogleOAuth2HandlerTest {
         verify(handler);
         PowerMock.verify(OAuth2Handler.class);
         verify(mockOAuthInfo);
+        verify(mockConfig);
         verify(mockCredentials);
         verify(mockCredentialsRToken);
         verify(mockDataSource);

--- a/src/java-test/com/zimbra/oauth/handlers/impl/YahooOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/YahooOAuth2HandlerTest.java
@@ -39,6 +39,7 @@ import org.powermock.reflect.Whitebox;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.client.ZDataSource;
 import com.zimbra.client.ZMailbox;
+import com.zimbra.cs.account.Account;
 import com.zimbra.oauth.handlers.impl.YahooOAuth2Handler.YahooConstants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
@@ -96,14 +97,14 @@ public class YahooOAuth2HandlerTest {
     @Before
     public void setUp() throws Exception {
         handler = PowerMock.createPartialMockForAllMethodsExcept(YahooOAuth2Handler.class,
-            "authorize", "authenticate", "buildAuthorizeUri");
+            "authorize", "authenticate");
+        Whitebox.setInternalState(handler, "config", mockConfig);
         Whitebox.setInternalState(handler, "relayKey", YahooConstants.RELAY_KEY);
-        Whitebox.setInternalState(handler, "clientRedirectUri", clientRedirectUri);
-        Whitebox.setInternalState(handler, "clientId", clientId);
-        Whitebox.setInternalState(handler, "clientSecret", clientSecret);
         Whitebox.setInternalState(handler, "authenticateUri", YahooConstants.AUTHENTICATE_URI);
+        Whitebox.setInternalState(handler, "authorizeUriTemplate",
+            YahooConstants.AUTHORIZE_URI_TEMPLATE);
+        Whitebox.setInternalState(handler, "client", YahooConstants.CLIENT_NAME);
         Whitebox.setInternalState(handler, "dataSource", mockDataSource);
-        Whitebox.setInternalState(handler, "authorizeUri", handler.buildAuthorizeUri(YahooConstants.AUTHORIZE_URI_TEMPLATE));
     }
 
     /**
@@ -120,9 +121,6 @@ public class YahooOAuth2HandlerTest {
             OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE))
                 .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE);
         expect(mockConfig.getString(OAuth2Constants.LC_ZIMBRA_SERVER_HOSTNAME)).andReturn(hostname);
-        expect(mockConfig.getString(String.format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE, YahooConstants.CLIENT_NAME))).andReturn(clientId);
-        expect(mockConfig.getString(String.format(OAuth2Constants.LC_OAUTH_CLIENT_SECRET_TEMPLATE, YahooConstants.CLIENT_NAME))).andReturn(clientSecret);
-        expect(mockConfig.getString(String.format(OAuth2Constants.LC_OAUTH_CLIENT_REDIRECT_URI_TEMPLATE, YahooConstants.CLIENT_NAME))).andReturn(clientRedirectUri);
         PowerMock.mockStatic(OAuthDataSource.class);
         expect(OAuthDataSource.createDataSource(YahooConstants.CLIENT_NAME,
             ZDataSource.SOURCE_HOST_YAHOO)).andReturn(mockDataSource);
@@ -146,8 +144,19 @@ public class YahooOAuth2HandlerTest {
     @Test
     public void testAuthorize() throws Exception {
         final String encodedUri = URLEncoder.encode(clientRedirectUri, OAuth2Constants.ENCODING);
+        final String expectedAuthorize = String.format(YahooConstants.AUTHORIZE_URI_TEMPLATE,
+            clientId, encodedUri, "code");
 
-        final String authorizeLocation = handler.authorize(null);
+        // expect buildAuthorize call
+        expect(handler.buildAuthorizeUri(YahooConstants.AUTHORIZE_URI_TEMPLATE, null))
+            .andReturn(expectedAuthorize);
+
+        replay(handler);
+
+        final String authorizeLocation = handler.authorize(null, null);
+
+        // verify build was called
+        verify(handler);
 
         assertNotNull(authorizeLocation);
         assertEquals(
@@ -157,7 +166,7 @@ public class YahooOAuth2HandlerTest {
 
     /**
      * Test method for {@link YahooOAuth2Handler#authenticate}<br>
-     * Validates that the authenticate method calls update datasource.
+     * Validates that the authenticate method calls sync datasource.
      *
      * @throws Exception If there are issues testing
      */
@@ -173,14 +182,31 @@ public class YahooOAuth2HandlerTest {
 
         PowerMock.mockStatic(OAuth2Handler.class);
 
+        expect(mockOAuthInfo.getAccount()).andReturn(null);
+        expect(mockConfig.getString(matches(
+            String.format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE, YahooConstants.CLIENT_NAME)),
+            matches(YahooConstants.CLIENT_NAME), anyObject())).andReturn(clientId);
+        expect(
+            mockConfig
+                .getString(
+                    matches(String.format(OAuth2Constants.LC_OAUTH_CLIENT_SECRET_TEMPLATE,
+                        YahooConstants.CLIENT_NAME)),
+                    matches(YahooConstants.CLIENT_NAME), anyObject())).andReturn(clientSecret);
+        expect(
+            mockConfig
+                .getString(
+                    matches(String.format(OAuth2Constants.LC_OAUTH_CLIENT_REDIRECT_URI_TEMPLATE,
+                        YahooConstants.CLIENT_NAME)),
+                    matches(YahooConstants.CLIENT_NAME), anyObject())).andReturn(clientRedirectUri);
         expect(handler.getZimbraMailbox(anyObject(String.class))).andReturn(mockZMailbox);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
-        .andReturn(mockCredentials);
+            .andReturn(mockCredentials);
         handler.validateTokenResponse(anyObject());
         EasyMock.expectLastCall().once();
         expect(mockCredentials.get("refresh_token")).andReturn(mockCredentialsRToken);
         expect(mockCredentialsRToken.asText()).andReturn(refreshToken);
-        expect(handler.getPrimaryEmail(anyObject(JsonNode.class))).andReturn(username);
+        expect(handler.getPrimaryEmail(anyObject(JsonNode.class), anyObject(Account.class)))
+            .andReturn(username);
 
         mockOAuthInfo.setClientId(matches(clientId));
         EasyMock.expectLastCall().once();
@@ -201,6 +227,7 @@ public class YahooOAuth2HandlerTest {
         replay(handler);
         PowerMock.replay(OAuth2Handler.class);
         replay(mockOAuthInfo);
+        replay(mockConfig);
         replay(mockCredentials);
         replay(mockCredentialsRToken);
         replay(mockDataSource);
@@ -210,6 +237,7 @@ public class YahooOAuth2HandlerTest {
         verify(handler);
         PowerMock.verify(OAuth2Handler.class);
         verify(mockOAuthInfo);
+        verify(mockConfig);
         verify(mockCredentials);
         verify(mockCredentialsRToken);
         verify(mockDataSource);

--- a/src/java-test/com/zimbra/oauth/utilities/OAuth2ResourceUtilitiesTest.java
+++ b/src/java-test/com/zimbra/oauth/utilities/OAuth2ResourceUtilitiesTest.java
@@ -35,6 +35,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.Account;
 import com.zimbra.oauth.handlers.IOAuth2Handler;
 import com.zimbra.oauth.managers.ClassManager;
 import com.zimbra.oauth.models.OAuthInfo;
@@ -76,12 +77,12 @@ public class OAuth2ResourceUtilitiesTest {
         final String location = "result-location";
 
         expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
-        expect(mockHandler.authorize(matches(relay))).andReturn(location);
+        expect(mockHandler.authorize(matches(relay), anyObject(Account.class))).andReturn(location);
 
         PowerMock.replay(ClassManager.class);
         replay(mockHandler);
 
-        OAuth2ResourceUtilities.authorize(client, relay);
+        OAuth2ResourceUtilities.authorize(client, relay, null);
 
         PowerMock.verify(ClassManager.class);
         verify(mockHandler);
@@ -115,7 +116,7 @@ public class OAuth2ResourceUtilitiesTest {
         PowerMock.replay(ClassManager.class);
         replay(mockHandler);
 
-        OAuth2ResourceUtilities.authenticate(client, params, zmAuthToken);
+        OAuth2ResourceUtilities.authenticate(client, params, null, zmAuthToken);
 
         PowerMock.verify(ClassManager.class);
         verify(mockHandler);
@@ -150,7 +151,7 @@ public class OAuth2ResourceUtilitiesTest {
         PowerMock.replay(ClassManager.class);
         replay(mockHandler);
 
-        OAuth2ResourceUtilities.authenticate(client, params, zmAuthToken);
+        OAuth2ResourceUtilities.authenticate(client, params, null, zmAuthToken);
 
         PowerMock.verify(ClassManager.class);
         verify(mockHandler);
@@ -187,7 +188,7 @@ public class OAuth2ResourceUtilitiesTest {
         PowerMock.replay(ClassManager.class);
         replay(mockHandler);
 
-        OAuth2ResourceUtilities.authenticate(client, params, zmAuthToken);
+        OAuth2ResourceUtilities.authenticate(client, params, null, zmAuthToken);
 
         PowerMock.verify(ClassManager.class);
         verify(mockHandler);

--- a/src/java/com/zimbra/oauth/handlers/IOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/IOAuth2Handler.java
@@ -37,6 +37,7 @@ public interface IOAuth2Handler {
      * Returns authorize endpoint for the client.
      *
      * @param relayState The location to direct the user after authenticating
+     * @param account The account to acquire configuration by access level
      * @return The authorize endpoint
      * @acct The user account
      * @throws ServiceException If there are issues determining the
@@ -45,8 +46,7 @@ public interface IOAuth2Handler {
     public String authorize(String relayState, Account acct) throws ServiceException;
 
     /**
-     * Authenticates a user with the endpoint and stores credentials in
-     * ephemeral-store.
+     * Authenticates a user with the endpoint and stores credentials.
      *
      * @param oauthInfo Contains a code provided by authorizing endpoint
      * @return True on success

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
@@ -104,6 +104,11 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
         protected static final String REQUIRED_SCOPES = "email";
 
         /**
+         * The scope delimiter for Google.
+         */
+        protected static final String SCOPE_DELIMITER = "+";
+
+        /**
          * The relay key for Google.
          */
         protected static final String RELAY_KEY = "state";
@@ -124,9 +129,12 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
      *
      * @param config For accessing configured properties
      */
-    public GoogleOAuth2Handler(Configuration config)  {
+    public GoogleOAuth2Handler(Configuration config) {
         super(config, GoogleConstants.CLIENT_NAME, GoogleConstants.HOST_GOOGLE);
         authenticateUri = GoogleConstants.AUTHENTICATE_URI;
+        authorizeUriTemplate = GoogleConstants.AUTHORIZE_URI_TEMPLATE;
+        requiredScopes = GoogleConstants.REQUIRED_SCOPES;
+        scopeDelimiter = GoogleConstants.SCOPE_DELIMITER;
         relayKey = GoogleConstants.RELAY_KEY;
         dataSource.addImportClass(View.contact.name(),
             GoogleContactsImport.class.getCanonicalName());

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
@@ -94,6 +94,11 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
         protected static final String CONTACTS_PAGE_SIZE = "100";
 
         /**
+         * The contacts image name template for Google.
+         */
+        protected static final String CONTACTS_IMAGE_NAME_TEMPLATE = "google-profile-image%s";
+
+        /**
          * The scope required for Google.
          */
         protected static final String REQUIRED_SCOPES = "email";

--- a/src/java/com/zimbra/oauth/handlers/impl/OutlookOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OutlookOAuth2Handler.java
@@ -108,6 +108,11 @@ public class OutlookOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
         protected static final String REQUIRED_SCOPES = "email";
 
         /**
+         * The scope delimiter for Outlook.
+         */
+        protected static final String SCOPE_DELIMITER = "+";
+
+        /**
          * The implementation name.
          */
         public static final String CLIENT_NAME = "outlook";
@@ -126,12 +131,15 @@ public class OutlookOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
     public OutlookOAuth2Handler(Configuration config) {
         super(config, OutlookConstants.CLIENT_NAME, OutlookConstants.HOST_OUTLOOK);
         authenticateUri = OutlookConstants.AUTHENTICATE_URI;
+        authorizeUriTemplate = OutlookConstants.AUTHORIZE_URI_TEMPLATE;
+        requiredScopes = OutlookConstants.REQUIRED_SCOPES;
+        scopeDelimiter = OutlookConstants.SCOPE_DELIMITER;
         relayKey = OutlookConstants.RELAY_KEY;
     }
 
     /**
-     * Validates that the token response has no errors, and contains
-     * the requested access information.
+     * Validates that the token response has no errors, and contains the
+     * requested access information.
      *
      * @param response The json token response
      * @throws ServiceException<br>
@@ -159,8 +167,8 @@ public class OutlookOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
                 throw ServiceException
                     .OPERATION_DENIED("The token request parameters are invalid.");
             case OutlookConstants.RESPONSE_ERROR_UNAUTHORIZED_CLIENT:
-                ZimbraLog.extensions
-                    .warn("The specified client details provided to the social service are invalid: "
+                ZimbraLog.extensions.warn(
+                    "The specified client details provided to the social service are invalid: "
                         + errorMsg);
                 throw ServiceException.OPERATION_DENIED(
                     "The specified client details provided to the social service are invalid.");

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
@@ -70,7 +70,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.common.service.ServiceException;
@@ -80,6 +82,7 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.DataSource;
 import com.zimbra.cs.account.DataSource.DataImport;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.mailbox.Contact.Attachment;
 import com.zimbra.cs.mime.ParsedContact;
 import com.zimbra.cs.service.mail.CreateContact;
 import com.zimbra.cs.service.util.ItemId;
@@ -120,8 +123,8 @@ public class YahooContactsImport implements DataImport {
     public YahooContactsImport(DataSource datasource) {
         mDataSource = datasource;
         try {
-           config = LdapConfiguration.buildConfiguration(YahooConstants.CLIENT_NAME);
-        } catch (ServiceException e) {
+            config = LdapConfiguration.buildConfiguration(YahooConstants.CLIENT_NAME);
+        } catch (final ServiceException e) {
             ZimbraLog.extensions.info("Error loading configuration for yahoo: %s", e.getMessage());
             ZimbraLog.extensions.debug(e);
         }
@@ -133,36 +136,44 @@ public class YahooContactsImport implements DataImport {
         String respContent = "";
         ParsedContact testContact = null;
         try {
-            final String url = String.format(YahooConstants.CONTACTS_URI_TEMPLATE, tokenAndGuid.getSecond(), "json", 10);
+            final String url = String.format(YahooConstants.CONTACTS_URI_TEMPLATE,
+                tokenAndGuid.getSecond(), "json", 10);
             final String authorizationHeader = String.format("Bearer %s", tokenAndGuid.getFirst());
             final JsonNode jsonResponse = getContactsRequest(url, authorizationHeader);
             respContent = jsonResponse.toString();
-            if(jsonResponse != null && jsonResponse.isObject()) {
-                if(jsonResponse.has("contacts") && jsonResponse.get("contacts").isObject()) {
+            if (jsonResponse != null && jsonResponse.isObject()) {
+                if (jsonResponse.has("contacts") && jsonResponse.get("contacts").isObject()) {
                     final JsonNode contactsObject = jsonResponse.get("contacts");
-                    if(contactsObject.has("contact") && contactsObject.get("contact").isArray()) {
+                    if (contactsObject.has("contact") && contactsObject.get("contact").isArray()) {
                         final JsonNode jsonContacts = contactsObject.get("contact");
-                        for(final JsonNode contactElement : jsonContacts) {
-                            final ParsedContact contact = YahooContactsUtil.parseYContact(contactElement, mDataSource);
-                            if(contact != null) {
+                        for (final JsonNode contactElement : jsonContacts) {
+                            final ParsedContact contact = YahooContactsUtil
+                                .parseYContact(contactElement, mDataSource);
+                            if (contact != null) {
                                 testContact = contact;
                                 break;
                             }
                         }
                     } else {
-                        ZimbraLog.extensions.debug("Did not find 'contact' element in 'contacts' object");
+                        ZimbraLog.extensions
+                            .debug("Did not find 'contact' element in 'contacts' object");
                     }
                 } else {
-                    ZimbraLog.extensions.debug("Did not find 'contacts' element in JSON response object");
+                    ZimbraLog.extensions
+                        .debug("Did not find 'contacts' element in JSON response object");
                 }
             } else {
                 ZimbraLog.extensions.debug("Did not find JSON response object");
             }
         } catch (UnsupportedOperationException | IOException e) {
-            throw ServiceException.FAILURE("Data source test failed. Failed to fetch contacts from  Yahoo Contacts API for testing", e);
+            throw ServiceException.FAILURE(
+                "Data source test failed. Failed to fetch contacts from  Yahoo Contacts API for testing",
+                e);
         }
-        if(testContact == null) {
-            throw ServiceException.FAILURE(String.format("Data source test failed. Failed to fetch contacts from  Yahoo Contacts API for testing. Response status code %d. Response status line: %s. Response body %s", respContent), null);
+        if (testContact == null) {
+            throw ServiceException.FAILURE(String.format(
+                "Data source test failed. Failed to fetch contacts from  Yahoo Contacts API for testing. Response status code %d. Response status line: %s. Response body %s",
+                respContent), null);
         }
     }
 
@@ -207,7 +218,8 @@ public class YahooContactsImport implements DataImport {
      * @throws ServiceException If there are issues retrieving the data
      * @throws IOException If there are issues executing the request
      */
-    protected JsonNode getContactsRequest(String url, String authorizationHeader) throws ServiceException, IOException {
+    protected JsonNode getContactsRequest(String url, String authorizationHeader)
+        throws ServiceException, IOException {
         final GetMethod get = new GetMethod(url);
         get.addRequestHeader(OAuth2Constants.HEADER_AUTHORIZATION, authorizationHeader);
         ZimbraLog.extensions.debug("Fetching contacts for import.");
@@ -233,7 +245,8 @@ public class YahooContactsImport implements DataImport {
         }
         String respContent = "";
         try {
-            final String url = String.format(YahooConstants.CONTACTS_URI_TEMPLATE, tokenAndGuid.getSecond(), "json", rev);
+            final String url = String.format(YahooConstants.CONTACTS_URI_TEMPLATE,
+                tokenAndGuid.getSecond(), "json", rev);
             final String authorizationHeader = String.format("Bearer %s", tokenAndGuid.getFirst());
             // log this only at the most verbose level, because this contains
             // privileged information
@@ -253,7 +266,8 @@ public class YahooContactsImport implements DataImport {
                         && contactsObject.get("contacts").isArray()) {
                         final JsonNode jsonContacts = contactsObject.get("contacts");
                         final List<ParsedContact> clist = new ArrayList<ParsedContact>();
-                        ZimbraLog.extensions.debug("Cycling through list to determine new contacts to add.");
+                        ZimbraLog.extensions
+                            .debug("Cycling through list to determine new contacts to add.");
                         for (final JsonNode contactElement : jsonContacts) {
                             if (contactElement.isObject() && contactElement.has("op")) {
                                 final String op = contactElement.get("op").asText();
@@ -307,7 +321,8 @@ public class YahooContactsImport implements DataImport {
     /**
      * The YahooContactsUtil class.<br>
      * Used to parse contacts from the Yahoo social service.<br>
-     * Source from the original YahooContactsUtil class by @author Greg Solovyev.
+     * Source from the original YahooContactsUtil class by @author Greg
+     * Solovyev.
      *
      * @author Zimbra API Team
      * @package com.zimbra.oauth.handlers.impl
@@ -350,6 +365,7 @@ public class YahooContactsImport implements DataImport {
         public static final String SUFFIX = "suffix";
 
         public static final Map<String, String> NAME_FIELDS_MAP = new HashMap<String, String>() {
+
             {
                 put(A_firstName, GIVENNAME);
                 put(A_middleName, MIDDLE);
@@ -367,6 +383,7 @@ public class YahooContactsImport implements DataImport {
         public static final String COUNTRY = "country";
         public static final String COUNTRYCODE = "countryCode";
         public static final Map<String, List<String>> WORK_ADDRESS_FIELDS_MAP = new HashMap<String, List<String>>() {
+
             {
                 put(A_workStreet, Arrays.asList(STREET));
                 put(A_workCity, Arrays.asList(CITY));
@@ -376,6 +393,7 @@ public class YahooContactsImport implements DataImport {
             }
         };
         public static final Map<String, List<String>> HOME_ADDRESS_FIELDS_MAP = new HashMap<String, List<String>>() {
+
             {
                 put(A_homeStreet, Arrays.asList(STREET));
                 put(A_homeCity, Arrays.asList(CITY));
@@ -385,6 +403,7 @@ public class YahooContactsImport implements DataImport {
             }
         };
         public static final Map<String, List<String>> OTHER_ADDRESS_FIELDS_MAP = new HashMap<String, List<String>>() {
+
             {
                 put(A_otherStreet, Arrays.asList(STREET));
                 put(A_otherCity, Arrays.asList(CITY));
@@ -398,12 +417,14 @@ public class YahooContactsImport implements DataImport {
         public static final String MONTH = "month";
         public static final String YEAR = "year";
         public static final Map<String, String> DATE_FIELDS_MAP = new HashMap<String, String>() {
+
             {
                 put("birthday", A_birthday);
                 put("anniversary", A_anniversary);
             }
         };
         public static final Map<String, String> PHONE_FIELDS_MAP = new HashMap<String, String>() {
+
             {
                 put("personal", A_homePhone);
                 put("work", A_workPhone);
@@ -416,6 +437,7 @@ public class YahooContactsImport implements DataImport {
             }
         };
         public static final Map<String, String> EMAIL_FIELDS_MAP = new HashMap<String, String>() {
+
             {
                 put("personal", A_email);
                 put("home", A_email);
@@ -423,6 +445,7 @@ public class YahooContactsImport implements DataImport {
             }
         };
         public static final Map<String, String> LINK_FIELDS_MAP = new HashMap<String, String>() {
+
             {
                 put("personal", A_homeURL);
                 put("home", A_homeURL);
@@ -534,14 +557,37 @@ public class YahooContactsImport implements DataImport {
         }
 
         public static void parseImageField(JsonNode fieldObject, String key,
-            Map<String, String> fields) {
+            List<Attachment> attachments) {
             if (fieldObject.has(VALUE)) {
                 final JsonNode valueObject = fieldObject.get(VALUE);
-                if (valueObject.isObject()) {
-                    if (valueObject.has(IMAGE_URL)) {
-                        final String value = valueObject.get(IMAGE_URL).asText();
-                        if (value != null && !value.isEmpty()) {
-                            fields.put(key, value);
+                if (valueObject.isObject() && valueObject.has(IMAGE_URL)) {
+                    final String imageUrl = valueObject.get(IMAGE_URL).asText();
+                    if (!StringUtils.isEmpty(imageUrl)) {
+                        try {
+                            // fetch the image
+                            final GetMethod get = new GetMethod(imageUrl);
+                            OAuth2Handler.executeRequest(get);
+                            // check for the content type header
+                            final Header ctypeHeader = get.getResponseHeader("Content-Type");
+                            if (ctypeHeader != null) {
+                                // grab content type header as string
+                                final String ctype = StringUtils.lowerCase(ctypeHeader.getValue());
+                                ZimbraLog.extensions.debug("The image Content-Type: %s", ctype);
+                                if (!StringUtils.isEmpty(ctype)) {
+                                    ZimbraLog.extensions.debug(
+                                        "Creating image attachment: %s as key: %s",
+                                        YahooConstants.CONTACTS_IMAGE_NAME, key);
+                                    final Attachment attachment = new Attachment(
+                                        OAuth2Utilities.decodeStream(get.getResponseBodyAsStream(),
+                                            OAuth2Constants.CONTACTS_IMAGE_BUFFER_SIZE),
+                                        ctype, key, YahooConstants.CONTACTS_IMAGE_NAME);
+                                    attachments.add(attachment);
+                                }
+                            }
+                        } catch (ServiceException | IOException e) {
+                            ZimbraLog.extensions
+                                .debug("There was an issue fetching a contact image.");
+                            // don't fail the rest
                         }
                     }
                 }
@@ -610,6 +656,7 @@ public class YahooContactsImport implements DataImport {
         public static ParsedContact parseYContact(JsonNode jsonContact, DataSource ds)
             throws ServiceException {
             final Map<String, String> contactFields = new HashMap<String, String>();
+            final List<Attachment> attachments = new ArrayList<Attachment>();
             if (jsonContact.has(FIELDS)) {
                 final JsonNode jsonFields = jsonContact.get(FIELDS);
                 if (jsonFields.isArray()) {
@@ -689,7 +736,7 @@ public class YahooContactsImport implements DataImport {
                                         parseSimpleField(fieldObj, A_jobTitle, contactFields);
                                         break;
                                     case image:
-                                        parseImageField(fieldObj, A_image, contactFields);
+                                        parseImageField(fieldObj, A_image, attachments);
                                         break;
                                     default:
                                         parseSimpleField(fieldObj, A_otherCustom1, contactFields);
@@ -704,7 +751,7 @@ public class YahooContactsImport implements DataImport {
                 }
             }
             if (!contactFields.isEmpty()) {
-                return new ParsedContact(contactFields);
+                return new ParsedContact(contactFields, attachments);
             } else {
                 return null;
             }

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
@@ -70,7 +70,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.lang.StringUtils;
 
@@ -321,8 +320,7 @@ public class YahooContactsImport implements DataImport {
     /**
      * The YahooContactsUtil class.<br>
      * Used to parse contacts from the Yahoo social service.<br>
-     * Source from the original YahooContactsUtil class by @author Greg
-     * Solovyev.
+     * Source from the original YahooContactsUtil class by @author Greg Solovyev.
      *
      * @author Zimbra API Team
      * @package com.zimbra.oauth.handlers.impl
@@ -556,6 +554,13 @@ public class YahooContactsImport implements DataImport {
             }
         }
 
+        /**
+         * Fetches an image from url and creates an attachment.
+         *
+         * @param fieldObject The json data containing the image url
+         * @param key The field key
+         * @param attachments The list of attachments to add to
+         */
         public static void parseImageField(JsonNode fieldObject, String key,
             List<Attachment> attachments) {
             if (fieldObject.has(VALUE)) {
@@ -567,22 +572,12 @@ public class YahooContactsImport implements DataImport {
                             // fetch the image
                             final GetMethod get = new GetMethod(imageUrl);
                             OAuth2Handler.executeRequest(get);
-                            // check for the content type header
-                            final Header ctypeHeader = get.getResponseHeader("Content-Type");
-                            if (ctypeHeader != null) {
-                                // grab content type header as string
-                                final String ctype = StringUtils.lowerCase(ctypeHeader.getValue());
-                                ZimbraLog.extensions.debug("The image Content-Type: %s", ctype);
-                                if (!StringUtils.isEmpty(ctype)) {
-                                    ZimbraLog.extensions.debug(
-                                        "Creating image attachment: %s as key: %s",
-                                        YahooConstants.CONTACTS_IMAGE_NAME, key);
-                                    final Attachment attachment = new Attachment(
-                                        OAuth2Utilities.decodeStream(get.getResponseBodyAsStream(),
-                                            OAuth2Constants.CONTACTS_IMAGE_BUFFER_SIZE),
-                                        ctype, key, YahooConstants.CONTACTS_IMAGE_NAME);
-                                    attachments.add(attachment);
-                                }
+                            // add to attachments
+                            final Attachment attachment = OAuth2Utilities
+                                .createAttachmentFromResponse(get, key,
+                                    YahooConstants.CONTACTS_IMAGE_NAME);
+                            if (attachment != null) {
+                                attachments.add(attachment);
                             }
                         } catch (ServiceException | IOException e) {
                             ZimbraLog.extensions

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
@@ -30,7 +30,6 @@ import static com.zimbra.common.mailbox.ContactConstants.A_homeState;
 import static com.zimbra.common.mailbox.ContactConstants.A_homeStreet;
 import static com.zimbra.common.mailbox.ContactConstants.A_homeURL;
 import static com.zimbra.common.mailbox.ContactConstants.A_imAddress1;
-import static com.zimbra.common.mailbox.ContactConstants.A_image;
 import static com.zimbra.common.mailbox.ContactConstants.A_jobTitle;
 import static com.zimbra.common.mailbox.ContactConstants.A_lastName;
 import static com.zimbra.common.mailbox.ContactConstants.A_middleName;
@@ -651,6 +650,7 @@ public class YahooContactsImport implements DataImport {
         public static ParsedContact parseYContact(JsonNode jsonContact, DataSource ds)
             throws ServiceException {
             final Map<String, String> contactFields = new HashMap<String, String>();
+            // will contain attachments in future iterations - assuming API support
             final List<Attachment> attachments = new ArrayList<Attachment>();
             if (jsonContact.has(FIELDS)) {
                 final JsonNode jsonFields = jsonContact.get(FIELDS);
@@ -731,7 +731,6 @@ public class YahooContactsImport implements DataImport {
                                         parseSimpleField(fieldObj, A_jobTitle, contactFields);
                                         break;
                                     case image:
-                                        parseImageField(fieldObj, A_image, attachments);
                                         break;
                                     default:
                                         parseSimpleField(fieldObj, A_otherCustom1, contactFields);

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
@@ -101,6 +101,16 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
         protected static final String CONTACTS_URI_TEMPLATE = "https://social.yahooapis.com/v1/user/%s/contacts?format=%s&view=sync&rev=%d";
 
         /**
+         * The contacts pagination size for Yahoo.
+         */
+        protected static final String CONTACTS_PAGE_SIZE = "100";
+
+        /**
+         * The contacts image name for Yahoo.
+         */
+        protected static final String CONTACTS_IMAGE_NAME = "yahoo-profile-image";
+
+        /**
          * The profile endpoint for Yahoo.
          */
         protected static final String PROFILE_URI = "https://social.yahooapis.com/v1/user/%s/profile";

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
@@ -101,11 +101,6 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
         protected static final String CONTACTS_URI_TEMPLATE = "https://social.yahooapis.com/v1/user/%s/contacts?format=%s&view=sync&rev=%d";
 
         /**
-         * The contacts pagination size for Yahoo.
-         */
-        protected static final String CONTACTS_PAGE_SIZE = "100";
-
-        /**
          * The contacts image name for Yahoo.
          */
         protected static final String CONTACTS_IMAGE_NAME = "yahoo-profile-image";

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
@@ -139,6 +139,7 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
     public YahooOAuth2Handler(Configuration config) {
         super(config, YahooConstants.CLIENT_NAME, ZDataSource.SOURCE_HOST_YAHOO);
         authenticateUri = YahooConstants.AUTHENTICATE_URI;
+        authorizeUriTemplate = YahooConstants.AUTHORIZE_URI_TEMPLATE;
         relayKey = YahooConstants.RELAY_KEY;
         // add associated import classes
         dataSource.addImportClass(View.contact.name(),
@@ -217,13 +218,9 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
     }
 
     /**
-     * Retrieves the primary email of the user with the specified guid and auth
-     * token.
+     * Retrieves the primary email of the user from the profile api.
      *
-     * @param guid The identifier for the user
-     * @param authToken The auth for the user
-     * @return The user's primary email
-     * @throws ServiceExcpetion If there are issues
+     * @see OAuth2Handler#getPrimaryEmail(JsonNode, Account)
      */
     @Override
     protected String getPrimaryEmail(JsonNode credentials, Account acct) throws ServiceException {
@@ -231,7 +228,8 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
         final String authToken = credentials.get("access_token").asText();
         final String url = String.format(YahooConstants.PROFILE_URI, guid);
         final GetMethod request = new GetMethod(url);
-        request.setRequestHeader(OAuth2Constants.HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
+        request.setRequestHeader(OAuth2Constants.HEADER_CONTENT_TYPE,
+            "application/x-www-form-urlencoded");
         request.setRequestHeader(OAuth2Constants.HEADER_ACCEPT, "application/json");
         request.setRequestHeader(OAuth2Constants.HEADER_AUTHORIZATION, "Bearer " + authToken);
 

--- a/src/java/com/zimbra/oauth/utilities/OAuth2Constants.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2Constants.java
@@ -37,6 +37,8 @@ public class OAuth2Constants {
 
     public static final String DATASOURCE_POLLING_INTERVAL = "1d";
 
+    public static final long CONTACTS_IMAGE_BUFFER_SIZE = 2048;
+
     // http related
     public static final String HEADER_AUTHORIZATION = "Authorization";
     public static final String HEADER_CONTENT_TYPE = "Content-Type";
@@ -67,8 +69,8 @@ public class OAuth2Constants {
     public static final String LC_OAUTH_CLIENT_REDIRECT_URI_TEMPLATE = "zm_oauth_%s_client_redirect_uri";
     public static final String LC_OAUTH_SCOPE_TEMPLATE = "zm_oauth_%s_scope";
     public static final String LC_OAUTH_IMPORT_CLASS_TEMPLATE = "zm_oauth_%s_import_class";
-    
-    
+
+
     public static final String OAUTH_CLIENT_ID = "client_id";
     public static final String OAUTH_CLIENT_SECRET = "client_secret";
     public static final String OAUTH_CLIENT_REDIRECT_URI = "client_redirect_uri";

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
@@ -49,14 +49,15 @@ public class OAuth2ResourceUtilities {
      *
      * @param client The client
      * @param relay The relay state
+     * @param account The user requesting
      * @return Location to redirect to
      * @acct the user account for which datasource is being setup
      * @throws ServiceException If there are issues
      */
-    public static final String authorize(String client, String relay, Account acct) throws ServiceException {
+    public static final String authorize(String client, String relay, Account account) throws ServiceException {
         final IOAuth2Handler oauth2Handler = ClassManager.getHandler(client);
         ZimbraLog.extensions.debug("Client : %s, handler:%s, relay:%s ", client, oauth2Handler,relay);
-        return oauth2Handler.authorize(relay, acct);
+        return oauth2Handler.authorize(relay, account);
     }
 
     /**
@@ -65,7 +66,7 @@ public class OAuth2ResourceUtilities {
      *
      * @param client The client
      * @param queryParams Map of query params
-     * @acct the user account for which datasource is being setup
+     * @param account The user requesting
      * @param zmAuthToken The Zimbra auth token
      * @return Location to redirect to
      * @throws ServiceException If there are issues

--- a/src/java/com/zimbra/oauth/utilities/OAuth2Utilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2Utilities.java
@@ -16,6 +16,9 @@
  */
 package com.zimbra.oauth.utilities;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -62,8 +65,7 @@ public class OAuth2Utilities {
      * @return Basic authorization header
      */
     public static String encodeBasicHeader(String user, String pass) {
-        return Base64.getEncoder()
-            .encodeToString(new String(user + ":" + pass).getBytes());
+        return Base64.getEncoder().encodeToString(new String(user + ":" + pass).getBytes());
     }
 
     /**
@@ -92,6 +94,37 @@ public class OAuth2Utilities {
             }
         }
         return resBuilder.build();
+    }
+
+    /**
+     * Decodes given stream with a size boundary.
+     *
+     * @param input An InputStream object
+     * @param size A boundary limit (optional : Use 0 to default)
+     * @return The the current contents of this output stream, as a byte array.
+     * @throws IOException
+     */
+    public static byte[] decodeStream(InputStream input, long size) throws IOException {
+        final long MIN_BUFFER_SIZE = 100;
+        final long MAX_BUFFER_SIZE = 4096;
+        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int lengthRead;
+        // buffer size must be within our bounds
+        if (size < MIN_BUFFER_SIZE || size > MAX_BUFFER_SIZE) {
+            size = MAX_BUFFER_SIZE;
+        }
+        final byte[] data = new byte[(int) size];
+        try {
+            // read until the end
+            while ((lengthRead = input.read(data)) != -1) {
+                buffer.write(data, 0, lengthRead);
+            }
+            buffer.flush();
+        } finally {
+            // always close the input
+            input.close();
+        }
+        return buffer.toByteArray();
     }
 
 }


### PR DESCRIPTION
Looking for commentary.

* Fetch profile images for Google and Yahoo.
  * Created with a default attachment name - if relevant can be found in yahoo/google constants
  * Yahoo does not appear to allow adding new contact images, unless I am missing something, so this functionality may only be supporting legacy contacts (pure speculation here).
* Create contacts and clear/free ParsedContact references every 100 contacts for Google
  * Not able to do this for Yahoo due to the way the `sync` style contact listing works, but I believe it is in our best interest to use that method since Yahoo will handle determining what is new for us - so after much testing with it I am leaving Yahoo as is.

Outlook should follow the same format given some contact api features.