### PR TITLE
ZCS-5305:Google Calendar Sync using caldav with Oauth2 datasource

### DIFF
--- a/src/java-test/com/zimbra/oauth/handlers/impl/FacebookOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/FacebookOAuth2HandlerTest.java
@@ -44,13 +44,13 @@ import com.zimbra.oauth.handlers.impl.FacebookOAuth2Handler.FacebookConstants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
-import com.zimbra.oauth.utilities.OAuthDataSource;
+import com.zimbra.oauth.utilities.OAuth2DataSource;
 
 /**
  * Test class for {@link FacebookOAuth2Handler}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ OAuthDataSource.class, OAuth2Handler.class, FacebookOAuth2Handler.class, ZMailbox.class })
+@PrepareForTest({ OAuth2DataSource.class, OAuth2Handler.class, FacebookOAuth2Handler.class, ZMailbox.class })
 @SuppressStaticInitializationFor("com.zimbra.client.ZMailbox")
 public class FacebookOAuth2HandlerTest {
 
@@ -67,7 +67,7 @@ public class FacebookOAuth2HandlerTest {
     /**
      * Mock data source handler property.
      */
-    protected OAuthDataSource mockDataSource = EasyMock.createMock(OAuthDataSource.class);
+    protected OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
     /**
      * ClientId for testing.
@@ -117,23 +117,23 @@ public class FacebookOAuth2HandlerTest {
      */
     @Test
     public void testFacebookOAuth2Handler() throws Exception {
-        final OAuthDataSource mockDataSource = EasyMock.createMock(OAuthDataSource.class);
+        final OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
         expect(mockConfig.getString(OAuth2Constants.LC_HOST_URI_TEMPLATE,
             OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE))
                 .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE);
         expect(mockConfig.getString(OAuth2Constants.LC_ZIMBRA_SERVER_HOSTNAME)).andReturn(hostname);
-        PowerMock.mockStatic(OAuthDataSource.class);
-        expect(OAuthDataSource.createDataSource(FacebookConstants.CLIENT_NAME,
+        PowerMock.mockStatic(OAuth2DataSource.class);
+        expect(OAuth2DataSource.createDataSource(FacebookConstants.CLIENT_NAME,
             FacebookConstants.HOST_FACEBOOK)).andReturn(mockDataSource);
 
         replay(mockConfig);
-        PowerMock.replay(OAuthDataSource.class);
+        PowerMock.replay(OAuth2DataSource.class);
 
         new FacebookOAuth2Handler(mockConfig);
 
         verify(mockConfig);
-        PowerMock.verify(OAuthDataSource.class);
+        PowerMock.verify(OAuth2DataSource.class);
     }
 
     /**
@@ -150,7 +150,7 @@ public class FacebookOAuth2HandlerTest {
             clientId, encodedUri, "code", FacebookConstants.REQUIRED_SCOPES);
 
         // expect buildAuthorize call
-        expect(handler.buildAuthorizeUri(FacebookConstants.AUTHORIZE_URI_TEMPLATE, null))
+        expect(handler.buildAuthorizeUri(FacebookConstants.AUTHORIZE_URI_TEMPLATE, null, "contact"))
             .andReturn(expectedAuthorize);
 
         replay(handler);
@@ -219,7 +219,7 @@ public class FacebookOAuth2HandlerTest {
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setRefreshToken(accessToken);
         EasyMock.expectLastCall().once();
-        mockDataSource.syncDatasource(mockZMailbox, mockOAuthInfo);
+        mockDataSource.syncDatasource(mockZMailbox, mockOAuthInfo, null);
         EasyMock.expectLastCall().once();
 
         replay(handler);

--- a/src/java-test/com/zimbra/oauth/handlers/impl/GoogleOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/GoogleOAuth2HandlerTest.java
@@ -43,13 +43,13 @@ import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleConstants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
-import com.zimbra.oauth.utilities.OAuthDataSource;
+import com.zimbra.oauth.utilities.OAuth2DataSource;
 
 /**
  * Test class for {@link GoogleOAuth2Handler}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ OAuthDataSource.class, OAuth2Handler.class, GoogleOAuth2Handler.class, ZMailbox.class })
+@PrepareForTest({ OAuth2DataSource.class, OAuth2Handler.class, GoogleOAuth2Handler.class, ZMailbox.class })
 @SuppressStaticInitializationFor("com.zimbra.client.ZMailbox")
 public class GoogleOAuth2HandlerTest {
 
@@ -66,7 +66,7 @@ public class GoogleOAuth2HandlerTest {
     /**
      * Mock data source handler property.
      */
-    protected OAuthDataSource mockDataSource = EasyMock.createMock(OAuthDataSource.class);
+    protected OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
     /**
      * ClientId for testing.
@@ -116,23 +116,23 @@ public class GoogleOAuth2HandlerTest {
      */
     @Test
     public void testGoogleOAuth2Handler() throws Exception {
-        final OAuthDataSource mockDataSource = EasyMock.createMock(OAuthDataSource.class);
+        final OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
         expect(mockConfig.getString(OAuth2Constants.LC_HOST_URI_TEMPLATE,
             OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE))
                 .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE);
         expect(mockConfig.getString(OAuth2Constants.LC_ZIMBRA_SERVER_HOSTNAME)).andReturn(hostname);
-        PowerMock.mockStatic(OAuthDataSource.class);
-        expect(OAuthDataSource.createDataSource(GoogleConstants.CLIENT_NAME,
+        PowerMock.mockStatic(OAuth2DataSource.class);
+        expect(OAuth2DataSource.createDataSource(GoogleConstants.CLIENT_NAME,
             GoogleConstants.HOST_GOOGLE)).andReturn(mockDataSource);
 
         replay(mockConfig);
-        PowerMock.replay(OAuthDataSource.class);
+        PowerMock.replay(OAuth2DataSource.class);
 
         new GoogleOAuth2Handler(mockConfig);
 
         verify(mockConfig);
-        PowerMock.verify(OAuthDataSource.class);
+        PowerMock.verify(OAuth2DataSource.class);
     }
 
     /**
@@ -149,7 +149,7 @@ public class GoogleOAuth2HandlerTest {
             clientId, encodedUri, "code", GoogleConstants.REQUIRED_SCOPES);
 
         // expect buildAuthorize call
-        expect(handler.buildAuthorizeUri(GoogleConstants.AUTHORIZE_URI_TEMPLATE, null))
+        expect(handler.buildAuthorizeUri(GoogleConstants.AUTHORIZE_URI_TEMPLATE, null, "contact"))
             .andReturn(expectedAuthorize);
 
         replay(handler);
@@ -221,7 +221,7 @@ public class GoogleOAuth2HandlerTest {
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setRefreshToken(refreshToken);
         EasyMock.expectLastCall().once();
-        mockDataSource.syncDatasource(mockZMailbox, mockOAuthInfo);
+        mockDataSource.syncDatasource(mockZMailbox, mockOAuthInfo, null);
         EasyMock.expectLastCall().once();
 
         replay(handler);

--- a/src/java-test/com/zimbra/oauth/handlers/impl/OutlookOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/OutlookOAuth2HandlerTest.java
@@ -43,13 +43,13 @@ import com.zimbra.oauth.handlers.impl.OutlookOAuth2Handler.OutlookConstants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
-import com.zimbra.oauth.utilities.OAuthDataSource;
+import com.zimbra.oauth.utilities.OAuth2DataSource;
 
 /**
  * Test class for {@link OutlookOAuth2Handler}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ OAuthDataSource.class, OAuth2Handler.class, OutlookOAuth2Handler.class, ZMailbox.class })
+@PrepareForTest({ OAuth2DataSource.class, OAuth2Handler.class, OutlookOAuth2Handler.class, ZMailbox.class })
 @SuppressStaticInitializationFor("com.zimbra.client.ZMailbox")
 public class OutlookOAuth2HandlerTest {
 
@@ -66,7 +66,7 @@ public class OutlookOAuth2HandlerTest {
     /**
      * Mock data source handler property.
      */
-    protected OAuthDataSource mockDataSource = EasyMock.createMock(OAuthDataSource.class);
+    protected OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
     /**
      * ClientId for testing.
@@ -116,23 +116,23 @@ public class OutlookOAuth2HandlerTest {
      */
     @Test
     public void testOutlookOAuth2Handler() throws Exception {
-        final OAuthDataSource mockDataSource = EasyMock.createMock(OAuthDataSource.class);
+        final OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
         expect(mockConfig.getString(OAuth2Constants.LC_HOST_URI_TEMPLATE,
             OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE))
                 .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE);
         expect(mockConfig.getString(OAuth2Constants.LC_ZIMBRA_SERVER_HOSTNAME)).andReturn(hostname);
-        PowerMock.mockStatic(OAuthDataSource.class);
-        expect(OAuthDataSource.createDataSource(OutlookConstants.CLIENT_NAME,
+        PowerMock.mockStatic(OAuth2DataSource.class);
+        expect(OAuth2DataSource.createDataSource(OutlookConstants.CLIENT_NAME,
             OutlookConstants.HOST_OUTLOOK)).andReturn(mockDataSource);
 
         replay(mockConfig);
-        PowerMock.replay(OAuthDataSource.class);
+        PowerMock.replay(OAuth2DataSource.class);
 
         new OutlookOAuth2Handler(mockConfig);
 
         verify(mockConfig);
-        PowerMock.verify(OAuthDataSource.class);
+        PowerMock.verify(OAuth2DataSource.class);
     }
 
     /**
@@ -149,7 +149,7 @@ public class OutlookOAuth2HandlerTest {
             clientId, encodedUri, "code", OutlookConstants.REQUIRED_SCOPES);
 
         // expect buildAuthorize call
-        expect(handler.buildAuthorizeUri(OutlookConstants.AUTHORIZE_URI_TEMPLATE, null))
+        expect(handler.buildAuthorizeUri(OutlookConstants.AUTHORIZE_URI_TEMPLATE, null, "contact"))
             .andReturn(expectedAuthorize);
 
         replay(handler);
@@ -221,7 +221,7 @@ public class OutlookOAuth2HandlerTest {
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setRefreshToken(refreshToken);
         EasyMock.expectLastCall().once();
-        mockDataSource.syncDatasource(mockZMailbox, mockOAuthInfo);
+        mockDataSource.syncDatasource(mockZMailbox, mockOAuthInfo, null);
         EasyMock.expectLastCall().once();
 
         replay(handler);

--- a/src/java-test/com/zimbra/oauth/handlers/impl/YahooOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/YahooOAuth2HandlerTest.java
@@ -44,13 +44,13 @@ import com.zimbra.oauth.handlers.impl.YahooOAuth2Handler.YahooConstants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
-import com.zimbra.oauth.utilities.OAuthDataSource;
+import com.zimbra.oauth.utilities.OAuth2DataSource;
 
 /**
  * Test class for {@link YahooOAuth2Handler}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ OAuthDataSource.class, OAuth2Handler.class, YahooOAuth2Handler.class, ZMailbox.class })
+@PrepareForTest({ OAuth2DataSource.class, OAuth2Handler.class, YahooOAuth2Handler.class, ZMailbox.class })
 @SuppressStaticInitializationFor("com.zimbra.client.ZMailbox")
 public class YahooOAuth2HandlerTest {
 
@@ -67,7 +67,7 @@ public class YahooOAuth2HandlerTest {
     /**
      * Mock data source handler property.
      */
-    protected OAuthDataSource mockDataSource = EasyMock.createMock(OAuthDataSource.class);
+    protected OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
     /**
      * ClientId for testing.
@@ -115,23 +115,23 @@ public class YahooOAuth2HandlerTest {
      */
     @Test
     public void testYahooOAuth2Handler() throws Exception {
-        final OAuthDataSource mockDataSource = EasyMock.createMock(OAuthDataSource.class);
+        final OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
         expect(mockConfig.getString(OAuth2Constants.LC_HOST_URI_TEMPLATE,
             OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE))
                 .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE);
         expect(mockConfig.getString(OAuth2Constants.LC_ZIMBRA_SERVER_HOSTNAME)).andReturn(hostname);
-        PowerMock.mockStatic(OAuthDataSource.class);
-        expect(OAuthDataSource.createDataSource(YahooConstants.CLIENT_NAME,
+        PowerMock.mockStatic(OAuth2DataSource.class);
+        expect(OAuth2DataSource.createDataSource(YahooConstants.CLIENT_NAME,
             ZDataSource.SOURCE_HOST_YAHOO)).andReturn(mockDataSource);
 
         replay(mockConfig);
-        PowerMock.replay(OAuthDataSource.class);
+        PowerMock.replay(OAuth2DataSource.class);
 
         new YahooOAuth2Handler(mockConfig);
 
         verify(mockConfig);
-        PowerMock.verify(OAuthDataSource.class);
+        PowerMock.verify(OAuth2DataSource.class);
     }
 
     /**
@@ -148,7 +148,7 @@ public class YahooOAuth2HandlerTest {
             clientId, encodedUri, "code");
 
         // expect buildAuthorize call
-        expect(handler.buildAuthorizeUri(YahooConstants.AUTHORIZE_URI_TEMPLATE, null))
+        expect(handler.buildAuthorizeUri(YahooConstants.AUTHORIZE_URI_TEMPLATE, null, "contact"))
             .andReturn(expectedAuthorize);
 
         replay(handler);
@@ -221,7 +221,7 @@ public class YahooOAuth2HandlerTest {
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setRefreshToken(refreshToken);
         EasyMock.expectLastCall().once();
-        mockDataSource.syncDatasource(mockZMailbox, mockOAuthInfo);
+        mockDataSource.syncDatasource(mockZMailbox, mockOAuthInfo, null);
         EasyMock.expectLastCall().once();
 
         replay(handler);

--- a/src/java/com/zimbra/oauth/handlers/impl/CalDavOAuth2DataImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/CalDavOAuth2DataImport.java
@@ -1,0 +1,105 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra OAuth Social Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.oauth.handlers.impl;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.DataSource;
+import com.zimbra.cs.datasource.CalDavDataImport;
+import com.zimbra.cs.dav.DavException;
+import com.zimbra.cs.dav.client.CalDavClient;
+import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleConstants;
+import com.zimbra.oauth.models.OAuthInfo;
+import com.zimbra.oauth.utilities.CalDavOAuth2Client;
+import com.zimbra.oauth.utilities.Configuration;
+import com.zimbra.oauth.utilities.LdapConfiguration;
+import com.zimbra.oauth.utilities.OAuth2Constants;
+import com.zimbra.oauth.utilities.OAuth2Utilities;
+import com.zimbra.oauth.utilities.OAuth2DataSource;
+
+public class CalDavOAuth2DataImport extends CalDavDataImport {
+
+    private Configuration config;
+
+    public CalDavOAuth2DataImport(DataSource ds) throws ServiceException {
+        super(ds);
+        try {
+            config = LdapConfiguration.buildConfiguration(GoogleConstants.CLIENT_NAME);
+        } catch (final ServiceException e) {
+            ZimbraLog.extensions.info("Error loading configuration for google caldav: %s", e.getMessage());
+            ZimbraLog.extensions.debug(e);
+        }
+    }
+
+    /**
+     * Initialize the dav client and refresh the access token
+     */
+    protected CalDavClient getClient() throws ServiceException, IOException, DavException {
+        if (mClient == null) {
+            mClient = new CalDavOAuth2Client(getTargetUrl());
+            mClient.setAppName(getAppName());
+            mClient.setDebugEnabled(dataSource.isDebugTraceEnabled());
+            mClient.setAccessToken(refresh());
+            mClient.login(getDefaultPrincipalUrl());
+        }
+        mClient.setAccessToken(refresh());
+        return mClient;
+    }
+
+    /**
+     * Retrieves the Google user accessToken.
+     *
+     * @return accessToken A live access token
+     * @throws ServiceException If there are issues
+     */
+    protected String refresh() throws ServiceException {
+        final Account acct = dataSource.getAccount();
+        final OAuthInfo oauthInfo = new OAuthInfo(new HashMap<String, String>());
+        final String refreshToken = OAuth2DataSource.getRefreshToken(dataSource);
+        final String clientId = config.getString(String
+            .format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE, GoogleConstants.CLIENT_NAME), GoogleConstants.CLIENT_NAME, acct);
+        final String clientSecret = config.getString(String
+            .format(OAuth2Constants.LC_OAUTH_CLIENT_SECRET_TEMPLATE, GoogleConstants.CLIENT_NAME), GoogleConstants.CLIENT_NAME,  acct);
+        final String clientRedirectUri = config.getString(String.format(
+            OAuth2Constants.LC_OAUTH_CLIENT_REDIRECT_URI_TEMPLATE, GoogleConstants.CLIENT_NAME), GoogleConstants.CLIENT_NAME, acct);
+
+        if (StringUtils.isEmpty(clientId) || StringUtils.isEmpty(clientSecret)
+            || StringUtils.isEmpty(clientRedirectUri)) {
+            throw ServiceException.FAILURE("Required config(id, secret and redirectUri) parameters are not provided.", null);
+        }
+        // set client specific properties
+        oauthInfo.setRefreshToken(refreshToken);
+        oauthInfo.setClientId(clientId);
+        oauthInfo.setClientSecret(clientSecret);
+        oauthInfo.setClientRedirectUri(clientRedirectUri);
+        oauthInfo.setTokenUrl(GoogleConstants.AUTHENTICATE_URI);
+
+        ZimbraLog.extensions.debug("Fetching access credentials for import.");
+        final JsonNode credentials = GoogleOAuth2Handler.getTokenRequest(oauthInfo,
+            OAuth2Utilities.encodeBasicHeader(clientId, clientSecret));
+
+        return credentials.get("access_token").asText();
+    }
+}

--- a/src/java/com/zimbra/oauth/handlers/impl/FacebookContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/FacebookContactsImport.java
@@ -40,7 +40,7 @@ import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.LdapConfiguration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
-import com.zimbra.oauth.utilities.OAuthDataSource;
+import com.zimbra.oauth.utilities.OAuth2DataSource;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -145,7 +145,7 @@ public class FacebookContactsImport implements DataImport {
     protected String refresh() throws ServiceException {
         Account acct = this.mDataSource.getAccount();
         final OAuthInfo oauthInfo = new OAuthInfo(new HashMap<String, String>());
-        final String refreshToken = OAuthDataSource.getRefreshToken(mDataSource);
+        final String refreshToken = OAuth2DataSource.getRefreshToken(mDataSource);
         final String clientId = config.getString(String
           .format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE, FacebookConstants.CLIENT_NAME),
           FacebookConstants.CLIENT_NAME, acct);

--- a/src/java/com/zimbra/oauth/handlers/impl/FacebookOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/FacebookOAuth2Handler.java
@@ -33,6 +33,7 @@ import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
 import com.zimbra.oauth.utilities.OAuth2Utilities;
+import com.zimbra.soap.admin.type.DataSourceType;
 
 /**
  * The FacebookOAuth2Handler class.<br>
@@ -216,7 +217,7 @@ public class FacebookOAuth2Handler extends OAuth2Handler implements IOAuth2Handl
         requiredScopes = FacebookConstants.REQUIRED_SCOPES;
         scopeDelimiter = FacebookConstants.SCOPE_DELIMITER;
         relayKey = FacebookConstants.RELAY_KEY;
-        dataSource.addImportClass(View.contact.name(),
+        dataSource.addImportClass(DataSourceType.oauth2contact.name(),
             FacebookContactsImport.class.getCanonicalName());
     }
 
@@ -260,7 +261,7 @@ public class FacebookOAuth2Handler extends OAuth2Handler implements IOAuth2Handl
         // store refreshToken
         oauthInfo.setUsername(username);
         oauthInfo.setRefreshToken(credentials.get("access_token").asText());
-        dataSource.syncDatasource(mailbox, oauthInfo);
+        dataSource.syncDatasource(mailbox, oauthInfo, null);
         return true;
     }
 

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -107,7 +107,7 @@ import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.LdapConfiguration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
 import com.zimbra.oauth.utilities.OAuth2Utilities;
-import com.zimbra.oauth.utilities.OAuthDataSource;
+import com.zimbra.oauth.utilities.OAuth2DataSource;
 
 /**
  * The GoogleContactsImport class.<br>
@@ -194,7 +194,7 @@ public class GoogleContactsImport implements DataImport {
     protected String refresh() throws ServiceException {
         final Account acct = this.mDataSource.getAccount();
         final OAuthInfo oauthInfo = new OAuthInfo(new HashMap<String, String>());
-        final String refreshToken = OAuthDataSource.getRefreshToken(mDataSource);
+        final String refreshToken = OAuth2DataSource.getRefreshToken(mDataSource);
         final String clientId = config.getString(String
             .format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE, GoogleConstants.CLIENT_NAME), GoogleConstants.CLIENT_NAME, acct);
         final String clientSecret = config.getString(String

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
@@ -90,7 +90,7 @@ import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.LdapConfiguration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
 import com.zimbra.oauth.utilities.OAuth2Utilities;
-import com.zimbra.oauth.utilities.OAuthDataSource;
+import com.zimbra.oauth.utilities.OAuth2DataSource;
 
 /**
  * The YahooContactsImport class.<br>
@@ -184,7 +184,7 @@ public class YahooContactsImport implements DataImport {
     protected Pair<String, String> refresh() throws ServiceException {
         Account acct = this.mDataSource.getAccount();
         final OAuthInfo oauthInfo = new OAuthInfo(new HashMap<String, String>());
-        final String refreshToken = OAuthDataSource.getRefreshToken(mDataSource);
+        final String refreshToken = OAuth2DataSource.getRefreshToken(mDataSource);
         final String clientId = config.getString(
             String.format(OAuth2Constants.LC_OAUTH_CLIENT_ID_TEMPLATE, YahooConstants.CLIENT_NAME), YahooConstants.CLIENT_NAME, acct);
         final String clientSecret = config.getString(String

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
@@ -29,6 +29,7 @@ import com.zimbra.cs.account.Account;
 import com.zimbra.oauth.handlers.IOAuth2Handler;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
+import com.zimbra.soap.admin.type.DataSourceType;
 
 /**
  * The YahooOAuth2Handler class.<br>
@@ -142,7 +143,7 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
         authorizeUriTemplate = YahooConstants.AUTHORIZE_URI_TEMPLATE;
         relayKey = YahooConstants.RELAY_KEY;
         // add associated import classes
-        dataSource.addImportClass(View.contact.name(),
+        dataSource.addImportClass(DataSourceType.oauth2contact.name(),
             YahooContactsImport.class.getCanonicalName());
     }
 

--- a/src/java/com/zimbra/oauth/utilities/CalDavOAuth2Client.java
+++ b/src/java/com/zimbra/oauth/utilities/CalDavOAuth2Client.java
@@ -1,0 +1,70 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra OAuth Social Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.oauth.utilities;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.auth.AuthPolicy;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+
+import com.zimbra.common.httpclient.HttpClientUtil;
+import com.zimbra.cs.dav.DavContext.Depth;
+import com.zimbra.cs.dav.client.CalDavClient;
+
+public class CalDavOAuth2Client extends CalDavClient {
+
+    public CalDavOAuth2Client(String baseUrl) {
+        super(baseUrl);
+    }
+
+    protected HttpMethod executeMethod(HttpMethod m, Depth d, String bodyForLogging) throws IOException {
+        HttpMethodParams p = m.getParams();
+        if ( p != null )
+            p.setCredentialCharset("UTF-8");
+
+        m.setDoAuthentication(true);
+        m.setRequestHeader("User-Agent", mUserAgent);
+        String depth = "0";
+        switch (d) {
+        case one:
+            depth = "1";
+            break;
+        case infinity:
+            depth = "infinity";
+            break;
+        case zero:
+            break;
+        default:
+            break;
+        }
+        m.setRequestHeader("Depth", depth);
+        final String authorizationHeader = String.format("Bearer %s", accessToken);
+        m.addRequestHeader(OAuth2Constants.HEADER_AUTHORIZATION, authorizationHeader);
+        m.setRequestHeader("Depth", depth);
+        logRequestInfo(m, bodyForLogging);
+        ArrayList<String> authPrefs = new ArrayList<String>();
+        authPrefs.add(AuthPolicy.BASIC);
+        mClient.getParams().setParameter(AuthPolicy.AUTH_SCHEME_PRIORITY, authPrefs);
+        mClient.getParams().setAuthenticationPreemptive(true);
+        HttpClientUtil.executeMethod(mClient, m);
+        logResponseInfo(m);
+        return m;
+    }
+}


### PR DESCRIPTION
added capability to create datasource for google caldav api. the newly added oauth data import class will refresh the access token and this token will be used for authentication in dav requests.