### PR TITLE
ZCS-4961 fixing failure on clicking not now on authentication

### DIFF
--- a/src/java-test/com/zimbra/oauth/utilities/OAuth2ResourceUtilitiesTest.java
+++ b/src/java-test/com/zimbra/oauth/utilities/OAuth2ResourceUtilitiesTest.java
@@ -113,7 +113,7 @@ public class OAuth2ResourceUtilitiesTest {
         expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
         expect(mockHandler.getAuthenticateParamKeys())
             .andReturn(Arrays.asList("code", "error", "state"));
-        mockHandler.verifyAuthenticateParams(anyObject());
+        mockHandler.verifyAndSplitAuthenticateParams(anyObject());
         EasyMock.expectLastCall();
         expect(mockHandler.authenticate(anyObject(OAuthInfo.class))).andReturn(true);
         expect(mockHandler.getRelay(anyObject())).andReturn(state);
@@ -149,7 +149,7 @@ public class OAuth2ResourceUtilitiesTest {
         expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
         expect(mockHandler.getAuthenticateParamKeys())
             .andReturn(Arrays.asList("code", "error", "state"));
-        mockHandler.verifyAuthenticateParams(anyObject());
+        mockHandler.verifyAndSplitAuthenticateParams(anyObject());
         EasyMock.expectLastCall().andThrow(ServiceException.PERM_DENIED(error));
         expect(mockHandler.getRelay(anyObject())).andReturn(state);
 
@@ -184,7 +184,7 @@ public class OAuth2ResourceUtilitiesTest {
         expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
         expect(mockHandler.getAuthenticateParamKeys())
             .andReturn(Arrays.asList("code", "error", "state"));
-        mockHandler.verifyAuthenticateParams(anyObject());
+        mockHandler.verifyAndSplitAuthenticateParams(anyObject());
         EasyMock.expectLastCall();
         expect(mockHandler.getRelay(anyObject())).andReturn(state);
         expect(mockHandler.authenticate(anyObject(OAuthInfo.class)))

--- a/src/java/com/zimbra/oauth/handlers/IOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/IOAuth2Handler.java
@@ -74,7 +74,7 @@ public interface IOAuth2Handler {
      * @param params The authenticate request params
      * @throws ServiceException If any params are invalid
      */
-    public void verifyAuthenticateParams(Map<String, String> params) throws ServiceException;
+    public void verifyAndSplitAuthenticateParams(Map<String, String> params) throws ServiceException;
 
     /**
      * Throws an exception if there are invalid params passed in.

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
@@ -84,7 +84,7 @@ public class OAuth2ResourceUtilities {
 
         // verify the expected params exist, with no errors
         try {
-            oauth2Handler.verifyAuthenticateParams(params);
+            oauth2Handler.verifyAndSplitAuthenticateParams(params);
         } catch (final ServiceException e) {
             if (StringUtils.equals(ServiceException.PERM_DENIED, e.getCode())) {
                 // if unauthorized, pass along the error message


### PR DESCRIPTION
Problem: error code 400 is shown on browser when user clicks on "NOT NOW" button on authentication screen on yahoo/google

Fix:
1. relay param in authenticate is needed. so keep it even if there is no value in relay.
2. renamed verifyAuthenticateParams to verifyAndSplitAuthenticateParams.
3. added constant for relay delimiter.

Testing Done:
1. tested functionality manually both positive and negative with yahoo.

Testing to be done by QA:
1. test functionality both positive and negative cases with yahoo/google/facebook
