### PR TITLE
ZCS-4961 fixing 400 failure when pressed not now without relay in url

### DIFF
--- a/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
@@ -393,14 +393,6 @@ public abstract class OAuth2Handler {
      * @see IOAuth2Handler#verifyAuthenticateParams()
      */
     public void verifyAndSplitAuthenticateParams(Map<String, String> params) throws ServiceException {
-        final String error = params.get("error");
-        // check for errors
-        if (!StringUtils.isEmpty(error)) {
-            throw ServiceException.PERM_DENIED(error);
-            // ensure code exists
-        } else if (!params.containsKey("code")) {
-            throw ServiceException.INVALID_REQUEST(OAuth2Constants.ERROR_INVALID_AUTH_CODE, null);
-        }
         if (params.containsKey(relayKey)) {
             String[] origVal = params.get(relayKey).split(RELAY_DELIMETER);
             if (origVal.length != 2) {
@@ -415,6 +407,14 @@ public abstract class OAuth2Handler {
             }
         } else {
             throw ServiceException.INVALID_REQUEST(OAuth2Constants.ERROR_TYPE_MISSING, null);
+        }
+        final String error = params.get("error");
+        // check for errors
+        if (!StringUtils.isEmpty(error)) {
+            throw ServiceException.PERM_DENIED(error);
+            // ensure code exists
+        } else if (!params.containsKey("code")) {
+            throw ServiceException.INVALID_REQUEST(OAuth2Constants.ERROR_INVALID_AUTH_CODE, null);
         }
     }
 

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
@@ -22,7 +22,6 @@ import org.apache.commons.httpclient.methods.GetMethod;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.client.ZDataSource;
-import com.zimbra.client.ZFolder.View;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;


### PR DESCRIPTION
**Problem:** if relay is not provided in url and not now is clicked on authentication page, 400 error is shown on browser.

**Fix:** 1st split relay and then check for error in authentication.

**Testing done:** Tested functionality manually on yahoo with and without relay.