### PR TITLE
ZCS-5172 Use fromString for error switch.

### DIFF
--- a/src/java/com/zimbra/oauth/handlers/impl/FacebookOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/FacebookOAuth2Handler.java
@@ -125,7 +125,12 @@ public class FacebookOAuth2Handler extends OAuth2Handler implements IOAuth2Handl
          * Too many requests.<br>
          * Picture profile URL rate-limit reached. Wait and retry the operation.
          */
-        RESPONSE_ERROR_TOO_MANY_REQUESTS("429");
+        RESPONSE_ERROR_TOO_MANY_REQUESTS("429"),
+
+        /**
+         * Default error.
+         */
+        DEFAULT_ERROR("DEFAULT_ERROR");
 
         /**
          * The value of this enum.
@@ -144,6 +149,21 @@ public class FacebookOAuth2Handler extends OAuth2Handler implements IOAuth2Handl
          */
         private FacebookErrorConstants(String constant) {
             this.constant = constant;
+        }
+
+        /**
+         * ValueOf wrapper for constants.
+         *
+         * @param code The code to check for
+         * @return Enum instance
+         */
+        protected static FacebookErrorConstants fromString(String code) {
+            for (final FacebookErrorConstants t : FacebookErrorConstants.values()) {
+                if (StringUtils.equals(t.getValue(), code)) {
+                    return t;
+                }
+            }
+            return DEFAULT_ERROR;
         }
 
     }
@@ -354,7 +374,7 @@ public class FacebookOAuth2Handler extends OAuth2Handler implements IOAuth2Handl
 
             errorCode = inErrorCodeRange(errorCode);
 
-            switch (FacebookErrorConstants.valueOf(errorCode)) {
+            switch (FacebookErrorConstants.fromString(errorCode)) {
                 case RESPONSE_ERROR_INVALID_CODE:
                     ZimbraLog.extensions.debug("Invalid request error from Facebook: "
                         + errorMsg);

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
@@ -19,6 +19,8 @@ package com.zimbra.oauth.handlers.impl;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
@@ -72,7 +74,12 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
         /**
          * Invalid request code from Google.
          */
-        RESPONSE_ERROR_INVALID_REQUEST("INVALID_REQUEST");
+        RESPONSE_ERROR_INVALID_REQUEST("INVALID_REQUEST"),
+
+        /**
+         * Default error.
+         */
+        DEFAULT_ERROR("DEFAULT_ERROR");
 
         /**
          * The value of this enum.
@@ -91,6 +98,21 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
          */
         private GoogleErrorConstants(String constant) {
             this.constant = constant;
+        }
+
+        /**
+         * ValueOf wrapper for constants.
+         *
+         * @param code The code to check for
+         * @return Enum instance
+         */
+        protected static GoogleErrorConstants fromString(String code) {
+            for (final GoogleErrorConstants t : GoogleErrorConstants.values()) {
+                if (StringUtils.equals(t.getValue(), code)) {
+                    return t;
+                }
+            }
+            return DEFAULT_ERROR;
         }
 
     }
@@ -265,7 +287,7 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
             final String error = response.get("error").asText();
             final JsonNode errorMsg = response.get("error_description");
             ZimbraLog.extensions.debug("Response from google: %s", response.asText());
-            switch (GoogleErrorConstants.valueOf(error.toUpperCase())) {
+            switch (GoogleErrorConstants.fromString(error.toUpperCase())) {
             case RESPONSE_ERROR_INVALID_REDIRECT_URI:
                 ZimbraLog.extensions.info(
                     "Redirect does not match the one found in authorization request: " + errorMsg);

--- a/src/java/com/zimbra/oauth/handlers/impl/OutlookOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OutlookOAuth2Handler.java
@@ -16,6 +16,8 @@
  */
 package com.zimbra.oauth.handlers.impl;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
@@ -80,7 +82,12 @@ public class OutlookOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
          * The authorization server does not support the response type in the
          * request.
          */
-        RESPONSE_ERROR_RESPONSE_TYPE("unsupported_response_type");
+        RESPONSE_ERROR_RESPONSE_TYPE("unsupported_response_type"),
+
+        /**
+         * Default error.
+         */
+        DEFAULT_ERROR("DEFAULT_ERROR");
 
         /**
          * The value of this enum.
@@ -99,6 +106,21 @@ public class OutlookOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
          */
         private OutlookErrorConstants(String constant) {
             this.constant = constant;
+        }
+
+        /**
+         * ValueOf wrapper for constants.
+         *
+         * @param code The code to check for
+         * @return Enum instance
+         */
+        protected static OutlookErrorConstants fromString(String code) {
+            for (final OutlookErrorConstants t : OutlookErrorConstants.values()) {
+                if (StringUtils.equals(t.getValue(), code)) {
+                    return t;
+                }
+            }
+            return DEFAULT_ERROR;
         }
 
     }
@@ -207,7 +229,7 @@ public class OutlookOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
         if (response.has("error")) {
             final String error = response.get("error").asText();
             final JsonNode errorMsg = response.get("error_description");
-            switch (OutlookErrorConstants.valueOf(error)) {
+            switch (OutlookErrorConstants.fromString(error)) {
             case RESPONSE_ERROR_INVALID_REQUEST:
                 ZimbraLog.extensions.warn("Invalid token request parameters: " + errorMsg);
                 throw ServiceException

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
@@ -19,6 +19,7 @@ package com.zimbra.oauth.handlers.impl;
 import java.io.IOException;
 
 import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.client.ZDataSource;
@@ -88,7 +89,12 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
         /**
          * Token expired response code from Yahoo.
          */
-        RESPONSE_ERROR_TOKEN_EXPIRED("TOKEN_EXPIRED");
+        RESPONSE_ERROR_TOKEN_EXPIRED("TOKEN_EXPIRED"),
+
+        /**
+         * Default error.
+         */
+        DEFAULT_ERROR("DEFAULT_ERROR");
 
         /**
          * The value of this enum.
@@ -107,6 +113,21 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
          */
         private YahooErrorConstants(String constant) {
             this.constant = constant;
+        }
+
+        /**
+         * ValueOf wrapper for constants.
+         *
+         * @param code The code to check for
+         * @return Enum instance
+         */
+        protected static YahooErrorConstants fromString(String code) {
+            for (final YahooErrorConstants t : YahooErrorConstants.values()) {
+                if (StringUtils.equals(t.getValue(), code)) {
+                    return t;
+                }
+            }
+            return DEFAULT_ERROR;
         }
     }
 
@@ -238,7 +259,7 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
         if (response.has("error")) {
             final String error = response.get("error").asText();
             final JsonNode errorMsg = response.get("error_description");
-            switch (YahooErrorConstants.valueOf(error)) {
+            switch (YahooErrorConstants.fromString(error)) {
             case RESPONSE_ERROR_ACCOUNT_NOT_AUTHORIZED:
                 ZimbraLog.extensions
                     .info("User did not provide authorization for this service: " + errorMsg);


### PR DESCRIPTION
* Using `fromString` to get an enum instance for the validation switch cases.