### PR TITLE
ZCS-5411 Fix unhandled error when missing type param

### DIFF
--- a/src/java/com/zimbra/oauth/handlers/IOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/IOAuth2Handler.java
@@ -39,7 +39,6 @@ public interface IOAuth2Handler {
      * @param params request params filtered with param keys
      * @param account The account to acquire configuration by access level
      * @return The authorize endpoint
-     * @acct The user account
      * @throws ServiceException If there are issues determining the
      *             endpoint
      */

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleOAuth2Handler.java
@@ -287,7 +287,7 @@ public class GoogleOAuth2Handler extends OAuth2Handler implements IOAuth2Handler
             final String error = response.get("error").asText();
             final JsonNode errorMsg = response.get("error_description");
             ZimbraLog.extensions.debug("Response from google: %s", response.asText());
-            switch (GoogleErrorConstants.fromString(error.toUpperCase())) {
+            switch (GoogleErrorConstants.fromString(StringUtils.upperCase(error))) {
             case RESPONSE_ERROR_INVALID_REDIRECT_URI:
                 ZimbraLog.extensions.info(
                     "Redirect does not match the one found in authorization request: " + errorMsg);

--- a/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
@@ -448,7 +448,7 @@ public abstract class OAuth2Handler {
         final String type = params.get(typeKey);
         if (StringUtils.isEmpty(type)) {
             ZimbraLog.extensions.debug("\"type\" not received in authorize request");
-            throw ServiceException.FAILURE("Missing type in authorize request", null);
+            throw ServiceException.INVALID_REQUEST("Missing type param in authorize request.", null);
         } else {
             //validate if type is valid
             OAuth2DataSource.getDataSourceTypeForOAuth2(type);

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooOAuth2Handler.java
@@ -259,7 +259,7 @@ public class YahooOAuth2Handler extends OAuth2Handler implements IOAuth2Handler 
         if (response.has("error")) {
             final String error = response.get("error").asText();
             final JsonNode errorMsg = response.get("error_description");
-            switch (YahooErrorConstants.fromString(error)) {
+            switch (YahooErrorConstants.fromString(StringUtils.upperCase(error))) {
             case RESPONSE_ERROR_ACCOUNT_NOT_AUTHORIZED:
                 ZimbraLog.extensions
                     .info("User did not provide authorization for this service: " + errorMsg);

--- a/src/java/com/zimbra/oauth/resources/ZOAuth2Servlet.java
+++ b/src/java/com/zimbra/oauth/resources/ZOAuth2Servlet.java
@@ -97,11 +97,10 @@ public class ZOAuth2Servlet extends ExtensionHttpHandler {
             }
         } catch (final ServiceException e) {
             ZimbraLog.extensions.errorQuietly("An unhandled oauth application error occurred.", e);
-            final Map<String, String> errorParams = new HashMap<String, String>();
-            errorParams.put(OAuth2HttpConstants.QUERY_ERROR.getValue(),
-                OAuth2ErrorConstants.ERROR_UNHANDLED_ERROR.getValue());
-            resp.sendRedirect(OAuth2ResourceUtilities
-                .addQueryParams(OAuth2Constants.DEFAULT_SUCCESS_REDIRECT.getValue(), errorParams));
+            resp.sendRedirect(OAuth2ResourceUtilities.addQueryParams(
+                OAuth2Constants.DEFAULT_SUCCESS_REDIRECT.getValue(),
+                OAuth2ResourceUtilities
+                    .mapError(OAuth2ErrorConstants.ERROR_UNHANDLED_ERROR.getValue(), null)));
             return;
         }
         ZimbraLog.extensions.debug("Authorization URI:%s", location);

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ErrorConstants.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ErrorConstants.java
@@ -33,7 +33,8 @@ public enum OAuth2ErrorConstants {
     ERROR_INVALID_ZM_AUTH_CODE_MSG("Invalid or missing Zimbra session."),
     ERROR_AUTHENTICATION_ERROR("authentication_error"),
     ERROR_UNHANDLED_ERROR("unhandled_error"),
-    ERROR_TYPE_MISSING("missing_type");
+    ERROR_TYPE_MISSING("missing_type"),
+    ERROR_PARAM_MISSING("missing_param");
 
     /**
      * The value of this enum.


### PR DESCRIPTION
We used failure during 4961, just editing to show a more helpful message when missing the `type` param. Won't handle logging cleanup for all the handlers in this ticket.

* Show invalid request when missing type param