### PR TITLE
ZCS-5172: fix code which reads scope from ldap attribute

### DIFF
--- a/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
@@ -241,7 +241,7 @@ public abstract class OAuth2Handler {
             : client + "_" + datasourceType;
         final String scope = StringUtils.join(new String[] { requiredScopes,
             config.getString(String.format(OAuth2ConfigConstants.LC_OAUTH_SCOPE_TEMPLATE.getValue(),
-                client, account), scopeIdentifier) },
+                client), scopeIdentifier, account) },
             scopeDelimiter);
 
         if (StringUtils.isEmpty(clientId) || StringUtils.isEmpty(clientRedirectUri)) {


### PR DESCRIPTION
logic to read scope from ldap attribute was broken by fix for bug ZCS-5172. fixed that code.