### PR TITLE
ZCS-5331 Removes token information from the logs.

### DIFF
--- a/src/java/com/zimbra/oauth/handlers/impl/FacebookContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/FacebookContactsImport.java
@@ -297,10 +297,7 @@ public class FacebookContactsImport implements DataImport {
                 // Facebook nextPageUrl if defined
                 final String url = buildContactsUrl(nextPageUrl, refreshToken);
                 nextPageUrl = null;
-                // log this only at the most verbose level, because this
-                // contains
-                // privileged information
-                ZimbraLog.extensions.debug("Attempting to sync Facebook contacts. URL: %s", url);
+                ZimbraLog.extensions.debug("Attempting to sync Facebook contacts.");
                 final JsonNode jsonResponse = getContactsRequest(url);
                 if (jsonResponse != null && jsonResponse.isContainerNode()) {
                     respContent = jsonResponse.toString();

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -374,10 +374,7 @@ public class GoogleContactsImport implements DataImport {
                     syncToken, pageToken);
                 // always set an empty page token during pagination
                 pageToken = null;
-                // log only at most verbose level, this contains privileged info
-                ZimbraLog.extensions.trace(
-                    "Attempting to sync Google contacts. URL: %s. authorizationHeader: %s", url,
-                    authorizationHeader);
+                ZimbraLog.extensions.debug("Attempting to sync Google contacts.");
                 // fetch contacts
                 final JsonNode jsonResponse = getContactsRequest(url, authorizationHeader);
                 if (jsonResponse != null && jsonResponse.isContainerNode()) {

--- a/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
@@ -200,7 +200,7 @@ public abstract class OAuth2Handler {
         JsonNode json = null;
         try {
             json = executeRequestForJson(request);
-            ZimbraLog.extensions.trace("Response for autn token request:%s", json);
+            ZimbraLog.extensions.debug("Request for auth token completed.");
         } catch (final IOException e) {
             ZimbraLog.extensions
                 .errorQuietly("There was an issue acquiring the authorization token.", e);

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
@@ -256,11 +256,7 @@ public class YahooContactsImport implements DataImport {
             final String url = String.format(YahooContactConstants.CONTACTS_URI_TEMPLATE.getValue(),
                 tokenAndGuid.getSecond(), "json", rev);
             final String authorizationHeader = String.format("Bearer %s", tokenAndGuid.getFirst());
-            // log this only at the most verbose level, because this contains
-            // privileged information
-            ZimbraLog.extensions.trace(
-                "Attempting to sync Yahoo contacts. URL: %s. authorizationHeader: %s", url,
-                authorizationHeader);
+            ZimbraLog.extensions.debug("Attempting to sync Yahoo contacts.");
             final JsonNode jsonResponse = getContactsRequest(url, authorizationHeader);
             respContent = jsonResponse.toString();
             // log this only at the most verbose level, because this contains


### PR DESCRIPTION
Removes private information, like access tokens, from showing up in the logs.