### PR TITLE
ZCS-4924 Add support for JWT auth.

### DIFF
--- a/src/java-test/com/zimbra/oauth/handlers/impl/FacebookOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/FacebookOAuth2HandlerTest.java
@@ -42,6 +42,7 @@ import org.powermock.reflect.Whitebox;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
 import com.zimbra.oauth.handlers.impl.FacebookOAuth2Handler.FacebookOAuth2Constants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
@@ -191,7 +192,7 @@ public class FacebookOAuth2HandlerTest {
     public void testAuthenticate() throws Exception {
         final String user_id = "1234567890";
         final String accessToken = "access-token";
-        final String zmAuthToken = "zm-auth-token";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
         final OAuthInfo mockOAuthInfo = EasyMock.createMock(OAuthInfo.class);
         final ZMailbox mockZMailbox = EasyMock.createMock(ZMailbox.class);
         final JsonNode mockCredentials = EasyMock.createMock(JsonNode.class);
@@ -214,7 +215,7 @@ public class FacebookOAuth2HandlerTest {
                 FacebookOAuth2Constants.CLIENT_NAME.getValue())),
             matches(FacebookOAuth2Constants.CLIENT_NAME.getValue()), anyObject()))
                 .andReturn(clientRedirectUri);
-        expect(handler.getZimbraMailbox(anyObject(String.class))).andReturn(mockZMailbox);
+        expect(handler.getZimbraMailbox(anyObject(AuthToken.class))).andReturn(mockZMailbox);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
             .andReturn(mockCredentials);
         handler.validateTokenResponse(anyObject(JsonNode.class));
@@ -232,7 +233,7 @@ public class FacebookOAuth2HandlerTest {
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setTokenUrl(matches(FacebookOAuth2Constants.AUTHENTICATE_URI.getValue()));
         EasyMock.expectLastCall().once();
-        expect(mockOAuthInfo.getZmAuthToken()).andReturn(zmAuthToken);
+        expect(mockOAuthInfo.getZmAuthToken()).andReturn(mockAuthToken);
         mockOAuthInfo.setUsername(user_id);
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setRefreshToken(accessToken);

--- a/src/java-test/com/zimbra/oauth/handlers/impl/GoogleOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/GoogleOAuth2HandlerTest.java
@@ -41,6 +41,7 @@ import org.powermock.reflect.Whitebox;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
 import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleOAuth2Constants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
@@ -190,7 +191,7 @@ public class GoogleOAuth2HandlerTest {
     public void testAuthenticate() throws Exception {
         final String username = "test-user@localhost";
         final String refreshToken = "refresh-token";
-        final String zmAuthToken = "zm-auth-token";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
         final OAuthInfo mockOAuthInfo = EasyMock.createMock(OAuthInfo.class);
         final ZMailbox mockZMailbox = EasyMock.createMock(ZMailbox.class);
         final JsonNode mockCredentials = EasyMock.createMock(JsonNode.class);
@@ -214,7 +215,7 @@ public class GoogleOAuth2HandlerTest {
             matches(GoogleOAuth2Constants.CLIENT_NAME.getValue()), anyObject()))
                 .andReturn(clientRedirectUri);
         expect(handler.getDatasourceCustomAttrs(anyObject())).andReturn(customAttrs);
-        expect(handler.getZimbraMailbox(anyObject(String.class))).andReturn(mockZMailbox);
+        expect(handler.getZimbraMailbox(anyObject(AuthToken.class))).andReturn(mockZMailbox);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
             .andReturn(mockCredentials);
         handler.validateTokenResponse(anyObject());
@@ -232,7 +233,7 @@ public class GoogleOAuth2HandlerTest {
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setTokenUrl(matches(GoogleOAuth2Constants.AUTHENTICATE_URI.getValue()));
         EasyMock.expectLastCall().once();
-        expect(mockOAuthInfo.getZmAuthToken()).andReturn(zmAuthToken);
+        expect(mockOAuthInfo.getZmAuthToken()).andReturn(mockAuthToken);
         mockOAuthInfo.setUsername(username);
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setRefreshToken(refreshToken);

--- a/src/java-test/com/zimbra/oauth/handlers/impl/OutlookOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/OutlookOAuth2HandlerTest.java
@@ -41,6 +41,7 @@ import org.powermock.reflect.Whitebox;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
 import com.zimbra.oauth.handlers.impl.OutlookOAuth2Handler.OutlookOAuth2Constants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
@@ -190,7 +191,7 @@ public class OutlookOAuth2HandlerTest {
     public void testAuthenticate() throws Exception {
         final String username = "test-user@localhost";
         final String refreshToken = "refresh-token";
-        final String zmAuthToken = "zm-auth-token";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
         final OAuthInfo mockOAuthInfo = EasyMock.createMock(OAuthInfo.class);
         final ZMailbox mockZMailbox = EasyMock.createMock(ZMailbox.class);
         final JsonNode mockCredentials = EasyMock.createMock(JsonNode.class);
@@ -212,7 +213,7 @@ public class OutlookOAuth2HandlerTest {
                 OutlookOAuth2Constants.CLIENT_NAME.getValue())),
             matches(OutlookOAuth2Constants.CLIENT_NAME.getValue()), anyObject()))
                 .andReturn(clientRedirectUri);
-        expect(handler.getZimbraMailbox(anyObject(String.class))).andReturn(mockZMailbox);
+        expect(handler.getZimbraMailbox(anyObject(AuthToken.class))).andReturn(mockZMailbox);
         expect(handler.getDatasourceCustomAttrs(anyObject())).andReturn(null);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
             .andReturn(mockCredentials);
@@ -231,7 +232,7 @@ public class OutlookOAuth2HandlerTest {
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setTokenUrl(matches(OutlookOAuth2Constants.AUTHENTICATE_URI.getValue()));
         EasyMock.expectLastCall().once();
-        expect(mockOAuthInfo.getZmAuthToken()).andReturn(zmAuthToken);
+        expect(mockOAuthInfo.getZmAuthToken()).andReturn(mockAuthToken);
         mockOAuthInfo.setUsername(username);
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setRefreshToken(refreshToken);

--- a/src/java-test/com/zimbra/oauth/handlers/impl/YahooOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/YahooOAuth2HandlerTest.java
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.zimbra.client.ZDataSource;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
 import com.zimbra.oauth.handlers.impl.YahooOAuth2Handler.YahooOAuth2Constants;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
@@ -186,7 +187,7 @@ public class YahooOAuth2HandlerTest {
     public void testAuthenticate() throws Exception {
         final String username = "test-user@localhost";
         final String refreshToken = "refresh-token";
-        final String zmAuthToken = "zm-auth-token";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
         final OAuthInfo mockOAuthInfo = EasyMock.createMock(OAuthInfo.class);
         final ZMailbox mockZMailbox = EasyMock.createMock(ZMailbox.class);
         final JsonNode mockCredentials = EasyMock.createMock(JsonNode.class);
@@ -208,7 +209,7 @@ public class YahooOAuth2HandlerTest {
                 YahooOAuth2Constants.CLIENT_NAME.getValue())),
             matches(YahooOAuth2Constants.CLIENT_NAME.getValue()), anyObject()))
                 .andReturn(clientRedirectUri);
-        expect(handler.getZimbraMailbox(anyObject(String.class))).andReturn(mockZMailbox);
+        expect(handler.getZimbraMailbox(anyObject(AuthToken.class))).andReturn(mockZMailbox);
         expect(handler.getDatasourceCustomAttrs(anyObject())).andReturn(null);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
             .andReturn(mockCredentials);
@@ -227,7 +228,7 @@ public class YahooOAuth2HandlerTest {
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setTokenUrl(matches(YahooOAuth2Constants.AUTHENTICATE_URI.getValue()));
         EasyMock.expectLastCall().once();
-        expect(mockOAuthInfo.getZmAuthToken()).andReturn(zmAuthToken);
+        expect(mockOAuthInfo.getZmAuthToken()).andReturn(mockAuthToken);
         mockOAuthInfo.setUsername(username);
         EasyMock.expectLastCall().once();
         mockOAuthInfo.setRefreshToken(refreshToken);

--- a/src/java-test/com/zimbra/oauth/utilities/OAuth2ResourceUtilitiesTest.java
+++ b/src/java-test/com/zimbra/oauth/utilities/OAuth2ResourceUtilitiesTest.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.servlet.http.Cookie;
+
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +37,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.account.AuthToken;
 import com.zimbra.oauth.handlers.IOAuth2Handler;
 import com.zimbra.oauth.managers.ClassManager;
 import com.zimbra.oauth.models.OAuthInfo;
@@ -43,7 +46,7 @@ import com.zimbra.oauth.models.OAuthInfo;
  * Test class for {@link OAuth2ResourceUtilities}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ ClassManager.class, OAuth2Utilities.class })
+@PrepareForTest({ ClassManager.class, OAuth2ResourceUtilities.class, OAuth2Utilities.class })
 public class OAuth2ResourceUtilitiesTest {
 
     /**
@@ -59,6 +62,8 @@ public class OAuth2ResourceUtilitiesTest {
     @Before
     public void setUp() throws Exception {
         PowerMock.mockStatic(ClassManager.class);
+        PowerMock.mockStaticPartial(OAuth2ResourceUtilities.class, "getAccount", "getAuthToken",
+            "isJWT");
         PowerMock.mockStatic(OAuth2Utilities.class);
     }
 
@@ -74,9 +79,19 @@ public class OAuth2ResourceUtilitiesTest {
         final String client = "test-client";
         final String relay = "test-relay";
         final String location = "result-location";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
 
         // expect the handler to be fetched
         expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
+        // expect the auth token to be fetched
+        OAuth2ResourceUtilities.getAuthToken(anyObject(), anyObject());
+        PowerMock.expectLastCall().andReturn(mockAuthToken);
+        // expect the account to be fetched
+        OAuth2ResourceUtilities.getAccount(anyObject(AuthToken.class));
+        PowerMock.expectLastCall().andReturn(null);
+        // expect isJWT to be called
+        OAuth2ResourceUtilities.isJWT(anyObject(AuthToken.class));
+        PowerMock.expectLastCall().andReturn(false);
         // expect the client's required params to be fetched
         expect(mockHandler.getAuthorizeParamKeys()).andReturn(Arrays.asList("relay", "type"));
         // expect to verify the present params
@@ -88,16 +103,75 @@ public class OAuth2ResourceUtilitiesTest {
         expect(mockHandler.authorize(params, null)).andReturn(location);
 
         PowerMock.replay(ClassManager.class);
+        PowerMock.replay(OAuth2ResourceUtilities.class);
         replay(mockHandler);
 
         // pass in multi-valued params and expect them to be parsed
         final Map<String, String[]> rawParams = new HashMap<String, String[]>();
         final String[] multiRelay = { relay };
         rawParams.put("relay", multiRelay);
-        OAuth2ResourceUtilities.authorize(client, rawParams, null);
+        OAuth2ResourceUtilities.authorize(client, new Cookie[] {}, new HashMap<String, String>(),
+            rawParams);
 
         PowerMock.verify(ClassManager.class);
+        PowerMock.verify(OAuth2ResourceUtilities.class);
         verify(mockHandler);
+    }
+
+    /**
+     * Test method for {@link OAuth2ResourceUtilities#authorize}<br>
+     * Validates that authorize passes along a given JWT to the handler.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAuthorizeWithJWT() throws Exception {
+        final String client = "test-client";
+        final String relay = "test-relay";
+        final String location = "result-location";
+        final String jwt = "test-jwt";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
+
+        // expect the handler to be fetched
+        expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
+        // expect the auth token to be fetched
+        OAuth2ResourceUtilities.getAuthToken(anyObject(), anyObject());
+        PowerMock.expectLastCall().andReturn(mockAuthToken);
+        // expect the account to be fetched
+        OAuth2ResourceUtilities.getAccount(anyObject(AuthToken.class));
+        PowerMock.expectLastCall().andReturn(null);
+        // expect isJWT to be called
+        OAuth2ResourceUtilities.isJWT(anyObject(AuthToken.class));
+        PowerMock.expectLastCall().andReturn(true);
+        // expect the encoded jwt to be fetched
+        expect(mockAuthToken.getEncoded()).andReturn(jwt);
+        // expect the client's required params to be fetched
+        expect(mockHandler.getAuthorizeParamKeys()).andReturn(Arrays.asList("relay", "type"));
+        // expect to verify the present params
+        mockHandler.verifyAuthorizeParams(anyObject());
+        EasyMock.expectLastCall();
+        // expect to have the handler authorize using a relay param
+        final Map<String, String> params = new HashMap<String, String>();
+        params.put(OAuth2HttpConstants.JWT_PARAM_KEY.getValue(), jwt);
+        params.put("relay", relay);
+        expect(mockHandler.authorize(params, null)).andReturn(location);
+
+        PowerMock.replay(ClassManager.class);
+        PowerMock.replay(OAuth2ResourceUtilities.class);
+        replay(mockHandler);
+        replay(mockAuthToken);
+
+        // pass in multi-valued params and expect them to be parsed
+        final Map<String, String[]> rawParams = new HashMap<String, String[]>();
+        final String[] multiRelay = { relay };
+        rawParams.put("relay", multiRelay);
+        OAuth2ResourceUtilities.authorize(client, new Cookie[] {}, new HashMap<String, String>(),
+            rawParams);
+
+        PowerMock.verify(ClassManager.class);
+        PowerMock.verify(OAuth2ResourceUtilities.class);
+        verify(mockHandler);
+        verify(mockAuthToken);
     }
 
     /**
@@ -112,12 +186,17 @@ public class OAuth2ResourceUtilitiesTest {
         final String client = "test-client";
         final String code = "test-code";
         final String state = "test-relay";
-        final String zmAuthToken = "test-zm-auth-token";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
         final Map<String, String[]> params = new HashMap<String, String[]>(3);
         params.put("code", new String[] { code });
         params.put("state", new String[] { state });
 
         expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
+        OAuth2ResourceUtilities.getAuthToken(anyObject(), anyObject(), anyObject(String.class));
+        PowerMock.expectLastCall().andReturn(mockAuthToken);
+        // expect the account to be fetched
+        OAuth2ResourceUtilities.getAccount(anyObject(AuthToken.class));
+        PowerMock.expectLastCall().andReturn(null);
         expect(mockHandler.getAuthenticateParamKeys())
             .andReturn(Arrays.asList("code", "error", "state"));
         mockHandler.verifyAndSplitAuthenticateParams(anyObject());
@@ -126,11 +205,62 @@ public class OAuth2ResourceUtilitiesTest {
         expect(mockHandler.getRelay(anyObject())).andReturn(state);
 
         PowerMock.replay(ClassManager.class);
+        PowerMock.replay(OAuth2ResourceUtilities.class);
         replay(mockHandler);
 
-        OAuth2ResourceUtilities.authenticate(client, params, null, zmAuthToken);
+        OAuth2ResourceUtilities.authenticate(client, new Cookie[] {}, new HashMap<String, String>(),
+            params);
 
         PowerMock.verify(ClassManager.class);
+        PowerMock.verify(OAuth2ResourceUtilities.class);
+        verify(mockHandler);
+    }
+
+    /**
+     * Test method for {@link OAuth2ResourceUtilities#authenticate}<br>
+     * Validates that authenticate uses the JWT from the relay.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAuthenticateWithJWT() throws Exception {
+        final String client = "test-client";
+        final String code = "test-code";
+        final String state = "test-relay";
+        final String jwt = "test-jwt";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
+        final Map<String, String> params = new HashMap<String, String>(3);
+        params.put("code", code);
+        params.put("state", state);
+        params.put(OAuth2HttpConstants.JWT_PARAM_KEY.getValue(), jwt);
+
+        PowerMock.mockStaticPartial(OAuth2ResourceUtilities.class, "getAccount", "getAuthToken",
+            "isJWT", "getParams");
+
+        expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
+        OAuth2ResourceUtilities.getParams(anyObject(), anyObject());
+        PowerMock.expectLastCall().andReturn(params);
+        OAuth2ResourceUtilities.getAuthToken(anyObject(), anyObject(), matches(jwt));
+        PowerMock.expectLastCall().andReturn(mockAuthToken);
+        // expect the account to be fetched
+        OAuth2ResourceUtilities.getAccount(anyObject(AuthToken.class));
+        PowerMock.expectLastCall().andReturn(null);
+        expect(mockHandler.getAuthenticateParamKeys())
+            .andReturn(Arrays.asList("code", "error", "state"));
+        mockHandler.verifyAndSplitAuthenticateParams(anyObject());
+        EasyMock.expectLastCall();
+        expect(mockHandler.authenticate(anyObject(OAuthInfo.class))).andReturn(true);
+        expect(mockHandler.getRelay(anyObject())).andReturn(state);
+
+        PowerMock.replay(ClassManager.class);
+        PowerMock.replay(OAuth2ResourceUtilities.class);
+        replay(mockHandler);
+
+        OAuth2ResourceUtilities.authenticate(client, new Cookie[] {}, new HashMap<String, String>(),
+            new HashMap<String, String[]>());
+
+        PowerMock.verify(ClassManager.class);
+        PowerMock.verify(OAuth2ResourceUtilities.class);
         verify(mockHandler);
     }
 
@@ -147,13 +277,18 @@ public class OAuth2ResourceUtilitiesTest {
         final String code = "test-code";
         final String error = "access_denied";
         final String state = "test-relay";
-        final String zmAuthToken = "test-zm-auth-token";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
         final Map<String, String[]> params = new HashMap<String, String[]>(3);
         params.put("code", new String[] { code });
         params.put("error", new String[] { error });
         params.put("state", new String[] { state });
 
         expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
+        OAuth2ResourceUtilities.getAuthToken(anyObject(), anyObject(), anyObject(String.class));
+        PowerMock.expectLastCall().andReturn(mockAuthToken);
+        // expect the account to be fetched
+        OAuth2ResourceUtilities.getAccount(anyObject(AuthToken.class));
+        PowerMock.expectLastCall().andReturn(null);
         expect(mockHandler.getAuthenticateParamKeys())
             .andReturn(Arrays.asList("code", "error", "state"));
         mockHandler.verifyAndSplitAuthenticateParams(anyObject());
@@ -161,11 +296,14 @@ public class OAuth2ResourceUtilitiesTest {
         expect(mockHandler.getRelay(anyObject())).andReturn(state);
 
         PowerMock.replay(ClassManager.class);
+        PowerMock.replay(OAuth2ResourceUtilities.class);
         replay(mockHandler);
 
-        OAuth2ResourceUtilities.authenticate(client, params, null, zmAuthToken);
+        OAuth2ResourceUtilities.authenticate(client, new Cookie[] {}, new HashMap<String, String>(),
+            params);
 
         PowerMock.verify(ClassManager.class);
+        PowerMock.verify(OAuth2ResourceUtilities.class);
         verify(mockHandler);
     }
 
@@ -182,13 +320,18 @@ public class OAuth2ResourceUtilitiesTest {
         final String code = "test-code";
         final String error = null;
         final String state = "test-relay";
-        final String zmAuthToken = "test-zm-auth-token";
+        final AuthToken mockAuthToken = EasyMock.createMock(AuthToken.class);
         final Map<String, String[]> params = new HashMap<String, String[]>(3);
         params.put("code", new String[] { code });
         params.put("error", new String[] { error });
         params.put("state", new String[] { state });
 
         expect(ClassManager.getHandler(matches(client))).andReturn(mockHandler);
+        OAuth2ResourceUtilities.getAuthToken(anyObject(), anyObject(), anyObject(String.class));
+        PowerMock.expectLastCall().andReturn(mockAuthToken);
+        // expect the account to be fetched
+        OAuth2ResourceUtilities.getAccount(anyObject(AuthToken.class));
+        PowerMock.expectLastCall().andReturn(null);
         expect(mockHandler.getAuthenticateParamKeys())
             .andReturn(Arrays.asList("code", "error", "state"));
         mockHandler.verifyAndSplitAuthenticateParams(anyObject());
@@ -198,11 +341,14 @@ public class OAuth2ResourceUtilitiesTest {
             .andThrow(ServiceException.PERM_DENIED("Access was denied during get_token!"));
 
         PowerMock.replay(ClassManager.class);
+        PowerMock.replay(OAuth2ResourceUtilities.class);
         replay(mockHandler);
 
-        OAuth2ResourceUtilities.authenticate(client, params, null, zmAuthToken);
+        OAuth2ResourceUtilities.authenticate(client, new Cookie[] {}, new HashMap<String, String>(),
+            params);
 
         PowerMock.verify(ClassManager.class);
+        PowerMock.verify(OAuth2ResourceUtilities.class);
         verify(mockHandler);
     }
 

--- a/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
@@ -40,6 +40,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.account.ZimbraAuthToken;
 import com.zimbra.oauth.handlers.IOAuth2Handler;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
@@ -511,7 +512,10 @@ public abstract class OAuth2Handler {
             final Options options = new Options();
             options.setUri(zimbraHostUri);
             final ZMailbox mbox = new ZMailbox(options);
-            mbox.initAuthToken(zmAuthToken.toZAuthToken());
+            // get a csrf unsecured token since we are internal
+            final AuthToken csrfUnsafeToken = ZimbraAuthToken
+                .getCsrfUnsecuredAuthToken(zmAuthToken);
+            mbox.initAuthToken(csrfUnsafeToken.toZAuthToken());
             return mbox;
         } catch (final ServiceException e) {
             ZimbraLog.extensions.errorQuietly(

--- a/src/java/com/zimbra/oauth/models/OAuthInfo.java
+++ b/src/java/com/zimbra/oauth/models/OAuthInfo.java
@@ -19,6 +19,7 @@ package com.zimbra.oauth.models;
 import java.util.Map;
 
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
 
 /**
  * The OAuthInfo class.<br>
@@ -58,7 +59,7 @@ public class OAuthInfo {
     /**
      * A Zimbra auth token.
      */
-    protected String zmAuthToken;
+    protected AuthToken zmAuthToken;
 
     /**
      * A username.
@@ -194,7 +195,7 @@ public class OAuthInfo {
      *
      * @return The Zimbra auth token
      */
-    public String getZmAuthToken() {
+    public AuthToken getZmAuthToken() {
         return zmAuthToken;
     }
 
@@ -203,7 +204,7 @@ public class OAuthInfo {
      *
      * @param zmAuthToken A Zimbra auth token
      */
-    public void setZmAuthToken(String zmAuthToken) {
+    public void setZmAuthToken(AuthToken zmAuthToken) {
         this.zmAuthToken = zmAuthToken;
     }
 

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ErrorConstants.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ErrorConstants.java
@@ -29,6 +29,7 @@ public enum OAuth2ErrorConstants {
 
     ERROR_ACCESS_DENIED("access_denied"),
     ERROR_INVALID_AUTH_CODE("invalid_auth_code"),
+    ERROR_INVALID_CLIENT("invalid_client"),
     ERROR_INVALID_ZM_AUTH_CODE("invalid_zm_auth_code"),
     ERROR_INVALID_ZM_AUTH_CODE_MSG("Invalid or missing Zimbra session."),
     ERROR_AUTHENTICATION_ERROR("authentication_error"),

--- a/src/java/com/zimbra/oauth/utilities/OAuth2HttpConstants.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2HttpConstants.java
@@ -36,7 +36,9 @@ public enum OAuth2HttpConstants {
     COOKIE_AUTH_TOKEN("ZM_AUTH_TOKEN"),
 
     OAUTH2_RELAY_KEY("state"),
-    OAUTH2_TYPE_KEY("type");
+    OAUTH2_TYPE_KEY("type"),
+
+    JWT_PARAM_KEY("jwt");
 
     /**
      * The value of this enum.

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
@@ -84,7 +84,7 @@ public class OAuth2ResourceUtilities {
         try {
             // verify params
             oauth2Handler.verifyAuthorizeParams(paramsForAuthorize);
-            if (JWTUtil.isJWT(authToken)) {
+            if (isJWT(authToken)) {
                 // if our credential is a jwt, pass it along too
                 paramsForAuthorize.put(OAuth2HttpConstants.JWT_PARAM_KEY.getValue(),
                     authToken.getEncoded());
@@ -186,7 +186,7 @@ public class OAuth2ResourceUtilities {
      * @param queryParams Map of request query parameters
      * @return Map of params found
      */
-    private static Map<String, String> getParams(List<String> expectedParams,
+    protected static Map<String, String> getParams(List<String> expectedParams,
         Map<String, String[]> queryParams) {
         final Map<String, String> foundParams = new HashMap<String, String>(expectedParams.size());
 
@@ -294,6 +294,16 @@ public class OAuth2ResourceUtilities {
     }
 
     /**
+     * Wraps JWTUtil.isJWT to simplify test mock.
+     *
+     * @param token The token in question
+     * @return True if the token is a jwt
+     */
+    protected static boolean isJWT(AuthToken token) {
+        return JWTUtil.isJWT(token);
+    }
+
+    /**
      * Retrieves authToken with jwt from state param as priority.<br>
      * If no jwt from state param exists, forwards to default cookie/header check.
      *
@@ -303,7 +313,7 @@ public class OAuth2ResourceUtilities {
      * @return An auth token
      * @throws ServiceException If there are issues creating the auth token
      */
-    private static AuthToken getAuthToken(Cookie[] cookies, Map<String, String> headers, String jwt)
+    protected static AuthToken getAuthToken(Cookie[] cookies, Map<String, String> headers, String jwt)
         throws ServiceException {
         AuthToken authToken = null;
         if (!StringUtils.isEmpty(jwt)) {
@@ -332,7 +342,7 @@ public class OAuth2ResourceUtilities {
      * @return An auth token
      * @throws ServiceException If there are issues creating the auth token
      */
-    private static AuthToken getAuthToken(Cookie[] cookies, Map<String, String> headers)
+    protected static AuthToken getAuthToken(Cookie[] cookies, Map<String, String> headers)
         throws ServiceException {
         AuthToken authToken = null;
         // search for JWT auth first (priority)
@@ -366,7 +376,7 @@ public class OAuth2ResourceUtilities {
      * @return The requesting user's account
      * @throws ServiceException If there are issues retrieving the account
      */
-    private static Account getAccount(AuthToken authToken) throws ServiceException {
+    protected static Account getAccount(AuthToken authToken) throws ServiceException {
         Account account = null;
         if (authToken != null) {
             if (authToken.isZimbraUser()) {

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
@@ -25,12 +25,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.common.util.L10nUtil.MsgKey;
+import com.zimbra.common.util.ZimbraCookie;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.account.AuthTokenException;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.ZimbraAuthToken;
+import com.zimbra.cs.account.ZimbraJWToken;
+import com.zimbra.cs.service.AuthProvider;
+import com.zimbra.cs.service.util.JWTUtil;
 import com.zimbra.oauth.handlers.IOAuth2Handler;
 import com.zimbra.oauth.managers.ClassManager;
 import com.zimbra.oauth.models.OAuthInfo;
@@ -48,21 +61,34 @@ public class OAuth2ResourceUtilities {
      * Handles client manager acquisition for authorize call.
      *
      * @param client The client
+     * @param cookies Request cookies
+     * @param headers Request headers required for authorize
      * @param params Request params
-     * @param account The user requesting
      * @return Location to redirect to
      * @throws ServiceException If there are issues
      */
-    public static final String authorize(String client, Map<String, String[]> params, Account account)
+    public static final String authorize(String client, Cookie[] cookies,
+        Map<String, String> headers, Map<String, String[]> params)
             throws ServiceException {
+        // search for credentials
+        final AuthToken authToken = getAuthToken(cookies, headers);
+        // get account first to auth the user
+        final Account account = getAccount(authToken);
+        // get handler next to validate the client
         final IOAuth2Handler oauth2Handler = ClassManager.getHandler(client);
         ZimbraLog.extensions.debug("Client : %s, handler:%s, state:%s, type:%s ", client,
-            oauth2Handler, params.get("state"), params.get(OAuth2HttpConstants.OAUTH2_TYPE_KEY.getValue()));
+            oauth2Handler, params.get("state"),
+            params.get(OAuth2HttpConstants.OAUTH2_TYPE_KEY.getValue()));
         final Map<String, String> paramsForAuthorize = getParams(
             oauth2Handler.getAuthorizeParamKeys(), params);
         try {
             // verify params
             oauth2Handler.verifyAuthorizeParams(paramsForAuthorize);
+            if (JWTUtil.isJWT(authToken)) {
+                // if our credential is a jwt, pass it along too
+                paramsForAuthorize.put(OAuth2HttpConstants.JWT_PARAM_KEY.getValue(),
+                    authToken.getEncoded());
+            }
             return oauth2Handler.authorize(paramsForAuthorize, account);
         } catch (final ServiceException e) {
             // return redirect error if invalid request
@@ -73,6 +99,9 @@ public class OAuth2ResourceUtilities {
             }
             // otherwise bubble error
             throw e;
+        } catch (final AuthTokenException e) {
+            throw ServiceException
+                .PERM_DENIED(OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE.getValue());
         }
     }
 
@@ -81,14 +110,17 @@ public class OAuth2ResourceUtilities {
      * authenticate call.
      *
      * @param client The client
+     * @param cookies Request cookies
+     * @param headers Request headers required for authenticate
      * @param queryParams Map of query params
-     * @param account The user requesting
-     * @param zmAuthToken The Zimbra auth token
      * @return Location to redirect to
      * @throws ServiceException If there are issues
      */
-    public static String authenticate(String client, Map<String, String[]> queryParams,
-        Account account, String zmAuthToken) throws ServiceException {
+    public static String authenticate(String client, Cookie[] cookies, Map<String, String> headers,
+        Map<String, String[]> queryParams) throws ServiceException {
+        // don't check for auth credentials until we can
+        // check the client's state param for a jwt
+        // get handler to validate the client
         final IOAuth2Handler oauth2Handler = ClassManager.getHandler(client);
         final Map<String, String> errorParams = new HashMap<String, String>();
         final Map<String, String> params = getParams(oauth2Handler.getAuthenticateParamKeys(),
@@ -108,33 +140,36 @@ public class OAuth2ResourceUtilities {
             }
         }
 
+        // search for credentials
+        final AuthToken authToken = getAuthToken(cookies, headers,
+            params.get(OAuth2HttpConstants.JWT_PARAM_KEY.getValue()));
+        if (authToken == null) {
+            // if there is no zimbra session, the zimbra account cannot be identified
+            mapError(errorParams, OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE.getValue(),
+                OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE_MSG.getValue());
+        }
+
+        // get account to auth the user
+        final Account account = getAccount(authToken);
+
         if (errorParams.isEmpty()) {
-            // if there is no zimbra auth code, the zimbra account cannot be
-            // identified
-            // this happens if the request has no zimbra cookie identifying a
-            // session
-            if (StringUtils.isEmpty(zmAuthToken)) {
-                mapError(errorParams, OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE.getValue(),
-                    OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE_MSG.getValue());
-            } else {
-                try {
-                    // no errors and auth token exists
-                    // attempt to authenticate
-                    final OAuthInfo authInfo = new OAuthInfo(params);
-                    authInfo.setAccount(account);
-                    authInfo.setZmAuthToken(zmAuthToken);
-                    oauth2Handler.authenticate(authInfo);
-                } catch (final ServiceException e) {
-                    // unauthorized does not have an error message associated
-                    // with it
-                    if (StringUtils.equals(ServiceException.PERM_DENIED, e.getCode())) {
-                        mapError(errorParams, OAuth2ErrorConstants.ERROR_ACCESS_DENIED.getValue(),
-                            null);
-                    } else {
-                        mapError(errorParams,
-                            OAuth2ErrorConstants.ERROR_AUTHENTICATION_ERROR.getValue(),
-                            e.getMessage());
-                    }
+            try {
+                // no errors and authToken exists
+                // attempt to authenticate
+                final OAuthInfo authInfo = new OAuthInfo(params);
+                authInfo.setAccount(account);
+                authInfo.setZmAuthToken(authToken);
+                oauth2Handler.authenticate(authInfo);
+            } catch (final ServiceException e) {
+                // unauthorized does not have an error message associated
+                // with it
+                if (StringUtils.equals(ServiceException.PERM_DENIED, e.getCode())) {
+                    mapError(errorParams, OAuth2ErrorConstants.ERROR_ACCESS_DENIED.getValue(),
+                        null);
+                } else {
+                    mapError(errorParams,
+                        OAuth2ErrorConstants.ERROR_AUTHENTICATION_ERROR.getValue(),
+                        e.getMessage());
                 }
             }
         }
@@ -256,6 +291,133 @@ public class OAuth2ResourceUtilities {
             errorParams.put(OAuth2HttpConstants.QUERY_ERROR_MSG.getValue(), message);
         }
         return errorParams;
+    }
+
+    /**
+     * Retrieves authToken with jwt from state param as priority.<br>
+     * If no jwt from state param exists, forwards to default cookie/header check.
+     *
+     * @param cookies Request cookies
+     * @param headers Request headers
+     * @param string JWT from client's state param
+     * @return An auth token
+     * @throws ServiceException If there are issues creating the auth token
+     */
+    private static AuthToken getAuthToken(Cookie[] cookies, Map<String, String> headers, String jwt)
+        throws ServiceException {
+        AuthToken authToken = null;
+        if (!StringUtils.isEmpty(jwt)) {
+            try {
+                jwt = URLDecoder.decode(jwt, OAuth2Constants.ENCODING.getValue());
+                final String salt = JWTUtil.getJWTSalt(jwt);
+                authToken = ZimbraJWToken.getJWToken(jwt, salt);
+                ZimbraLog.extensions.debug("Using jwt from state param for auth token.");
+            } catch (final AuthTokenException | UnsupportedEncodingException e) {
+                ZimbraLog.extensions.debug("Unable to validate JWT.");
+                throw ServiceException.PERM_DENIED("Unable to validate JWT.");
+            }
+        } else {
+            // no jwt in state param, check headers and cookies
+            authToken = getAuthToken(cookies, headers);
+        }
+        return authToken;
+    }
+
+    /**
+     * Retrieves authToken from header or cookie.<br>
+     * JWT is searched for as priority, then cookie.
+     *
+     * @param cookies Request cookies
+     * @param headers Request headers
+     * @return An auth token
+     * @throws ServiceException If there are issues creating the auth token
+     */
+    private static AuthToken getAuthToken(Cookie[] cookies, Map<String, String> headers)
+        throws ServiceException {
+        AuthToken authToken = null;
+        // search for JWT auth first (priority)
+        final String salt = getFromCookie(cookies, ZimbraCookie.COOKIE_ZM_JWT);
+        final String jwtString = headers.get(OAuth2HttpConstants.HEADER_AUTHORIZATION.getValue());
+        try {
+            if (!StringUtils.isEmpty(jwtString) && !StringUtils.isEmpty(salt)) {
+                authToken = ZimbraJWToken
+                    .getJWToken(StringUtils.substringAfter(jwtString, "Bearer "), salt);
+            }
+            if (authToken == null) {
+                // if we couldn't find a JWT, search for cookie auth
+                final String cookieString = getFromCookie(cookies,
+                    ZimbraCookie.authTokenCookieName(false));
+                authToken = ZimbraAuthToken.getAuthToken(cookieString);
+
+            }
+        } catch (final AuthTokenException e) {
+            ZimbraLog.extensions.info("Error authenticating user.");
+            throw ServiceException.PERM_DENIED(HttpServletResponse.SC_UNAUTHORIZED + ": "
+                + L10nUtil.getMessage(MsgKey.errMustAuthenticate));
+        }
+        return authToken;
+    }
+
+    /**
+     * Returns the requesting user's account.<br>
+     * Throws an exception if an account cannot be retrieved.
+     *
+     * @param authToken The auth token to retrieve the account with
+     * @return The requesting user's account
+     * @throws ServiceException If there are issues retrieving the account
+     */
+    private static Account getAccount(AuthToken authToken) throws ServiceException {
+        Account account = null;
+        if (authToken != null) {
+            if (authToken.isZimbraUser()) {
+                if (!authToken.isRegistered()) {
+                    throw ServiceException.PERM_DENIED(HttpServletResponse.SC_UNAUTHORIZED + ": "
+                        + L10nUtil.getMessage(MsgKey.errMustAuthenticate));
+                }
+                try {
+                    account = AuthProvider.validateAuthToken(Provisioning.getInstance(),
+                        authToken, false);
+                } catch (final ServiceException e) {
+                    throw ServiceException.PERM_DENIED(HttpServletResponse.SC_UNAUTHORIZED + ": "
+                        + L10nUtil.getMessage(MsgKey.errMustAuthenticate));
+                }
+            } else {
+                throw ServiceException.PERM_DENIED(HttpServletResponse.SC_UNAUTHORIZED + ": "
+                    + L10nUtil.getMessage(MsgKey.errMustAuthenticate));
+            }
+        } else {
+            throw ServiceException.PERM_DENIED(HttpServletResponse.SC_UNAUTHORIZED + ": "
+                + L10nUtil.getMessage(MsgKey.errMustAuthenticate));
+        }
+
+        if (account == null) {
+            throw ServiceException.PERM_DENIED(HttpServletResponse.SC_UNAUTHORIZED + ": "
+                + L10nUtil.getMessage(MsgKey.errMustAuthenticate));
+        }
+
+        ZimbraLog.extensions.debug("Account is:%s", account);
+
+        return account;
+    }
+
+    /**
+     * Retrieves a cookie from the cookie jar.
+     *
+     * @param cookies Cookie jar
+     * @param cookieName The specific cookie we need
+     * @return A cookie
+     */
+    private static String getFromCookie(Cookie [] cookies, String cookieName) {
+        String encodedAuthToken = null;
+        if (cookies != null) {
+            for (int i = 0; i < cookies.length; i++) {
+                if (cookies[i].getName().equals(cookieName)) {
+                    encodedAuthToken = cookies[i].getValue();
+                    break;
+                }
+            }
+        }
+        return encodedAuthToken;
     }
 
 }

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
@@ -319,7 +319,7 @@ public class OAuth2ResourceUtilities {
         if (!StringUtils.isEmpty(jwt)) {
             try {
                 jwt = URLDecoder.decode(jwt, OAuth2Constants.ENCODING.getValue());
-                final String salt = JWTUtil.getJWTSalt(jwt);
+                final String salt = getFromCookie(cookies, ZimbraCookie.COOKIE_ZM_JWT);
                 authToken = ZimbraJWToken.getJWToken(jwt, salt);
                 ZimbraLog.extensions.debug("Using jwt from state param for auth token.");
             } catch (final AuthTokenException | UnsupportedEncodingException e) {

--- a/src/java/com/zimbra/oauth/utilities/OAuth2Utilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2Utilities.java
@@ -232,4 +232,5 @@ public class OAuth2Utilities {
         HttpProxyUtil.configureProxy(httpClient);
         return httpClient;
     }
+
 }


### PR DESCRIPTION
Per discussion, I went with option 1 on the jira ticket - implementing via the state parameter.

A JWT is searched for via the `Authorization` header on the `authorize` request. The encoded token is appended to the `state` relay sent to the social service and bounced back to the `authenticate` callback where is it checked for in the returning `state` relay, before the usual places are checked (headers, cookies).

* Basic JWT support for all clients
  * Priority given to jwt, falling back to cookies if none
* Moved authentication logic from servlet class into the resource class for ease of access since relay parsing requires some assistance from the handlers due to some clients having odd key names (e.g. twitter).
* Replaced servlet exceptions because we weren't handling redirect for them, resulting in 500s.
* Switched local getZMailbox implementation - we probably need to update `ZMailbox#getByAuthToken` methods to also `setJWToken` (depending on type) for the auth request instead of only `setAuthToken`.

Looking for feedback!