### PR TITLE
ZCS-5596 Add client identifier to ds folder name.

### DIFF
--- a/src/java/com/zimbra/oauth/utilities/OAuth2Constants.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2Constants.java
@@ -32,7 +32,7 @@ public enum OAuth2Constants {
 
     DEFAULT_SUCCESS_REDIRECT("/"),
     DEFAULT_HOST_URI_TEMPLATE("https://%s:443"),
-    DEFAULT_OAUTH_FOLDER_TEMPLATE("%s-%s"),
+    DEFAULT_OAUTH_FOLDER_TEMPLATE("%s-%s-%s"),
 
     DATASOURCE_POLLING_INTERVAL("1d"),
 

--- a/src/java/com/zimbra/oauth/utilities/OAuth2DataSource.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2DataSource.java
@@ -124,7 +124,7 @@ public class OAuth2DataSource {
         final String refreshToken = credentials.getRefreshToken();
         final String type = credentials.getParam("type");
         final String dsFolderName = String
-                .format(OAuth2Constants.DEFAULT_OAUTH_FOLDER_TEMPLATE.getValue(), username, type);
+                .format(OAuth2Constants.DEFAULT_OAUTH_FOLDER_TEMPLATE.getValue(), username, type, client);
         try {
             // get datasource, create if missing
             ZDataSource osource = mailbox.getDataSourceByName(dsFolderName);


### PR DESCRIPTION
* Add client identifier to ds folder name.

Resolves issues for clients with ambiguous user identifiers.

See ticket for details.