### PR TITLE
ZCS-5594 Possible NPE on unauthenticated request.

### DIFF
--- a/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
@@ -357,7 +357,9 @@ public class OAuth2ResourceUtilities {
                 // if we couldn't find a JWT, search for cookie auth
                 final String cookieString = getFromCookie(cookies,
                     ZimbraCookie.authTokenCookieName(false));
-                authToken = ZimbraAuthToken.getAuthToken(cookieString);
+                if (!StringUtils.isEmpty(cookieString)) {
+                    authToken = ZimbraAuthToken.getAuthToken(cookieString);
+                }
 
             }
         } catch (final AuthTokenException e) {


### PR DESCRIPTION
* Fix NPE on unauthenticated request

Logged out state on the `authorize` url results in an NPE. Does not affect regular flow.

See ticket for details.