### PR TITLE
ZCS-2691 Create DataSource implementation for LinkedIn contacts via oAuth

### DIFF
--- a/src/java/com/zimbra/oauth/handlers/impl/LinkedinContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/LinkedinContactsImport.java
@@ -1,0 +1,76 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra OAuth Social Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.oauth.handlers.impl;
+
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.DataSource;
+import com.zimbra.cs.account.DataSource.DataImport;
+import com.zimbra.oauth.handlers.impl.LinkedinOAuth2Handler.LinkedinOAuth2Constants;
+import com.zimbra.oauth.utilities.Configuration;
+import com.zimbra.oauth.utilities.LdapConfiguration;
+
+/**
+ * The FacebookContactsImport class.<br>
+ * Used to sync contacts from the Facebook social service.<br>
+ * Source from the original YahooContactsImport class by @author Greg Solovyev.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.oauth.handlers.impl
+ * @copyright Copyright © 2018
+ */
+public class LinkedinContactsImport implements DataImport {
+
+    /**
+     * The datasource under import.
+     */
+    private final DataSource mDataSource;
+
+    /**
+     * Configuration wrapper.
+     */
+    private Configuration config;
+
+    /**
+     * Constructor.
+     *
+     * @param datasource The datasource to set
+     */
+    public LinkedinContactsImport(DataSource datasource) {
+        mDataSource = datasource;
+        try {
+            config = LdapConfiguration.buildConfiguration(LinkedinOAuth2Constants.CLIENT_NAME.getValue());
+        } catch (final ServiceException e) {
+            ZimbraLog.extensions.info("Error loading configuration for Linkedin: %s",
+                e.getMessage());
+            ZimbraLog.extensions.debug(e);
+        }
+    }
+
+    @Override
+    public void test() throws ServiceException {
+        // to be implemented with contact sync
+    }
+
+    @Override
+    public void importData(List<Integer> folderIds, boolean fullSync) throws ServiceException {
+        // to be implemented with contact sync
+    }
+}

--- a/src/java/com/zimbra/oauth/handlers/impl/LinkedinOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/LinkedinOAuth2Handler.java
@@ -1,0 +1,231 @@
+package com.zimbra.oauth.handlers.impl;
+
+import java.io.IOException;
+
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.zimbra.client.ZMailbox;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.oauth.handlers.IOAuth2Handler;
+import com.zimbra.oauth.models.OAuthInfo;
+import com.zimbra.oauth.utilities.Configuration;
+import com.zimbra.oauth.utilities.OAuth2ConfigConstants;
+import com.zimbra.oauth.utilities.OAuth2HttpConstants;
+import com.zimbra.oauth.utilities.OAuth2Utilities;
+import com.zimbra.soap.admin.type.DataSourceType;
+
+public class LinkedinOAuth2Handler extends OAuth2Handler implements IOAuth2Handler {
+    protected enum LinkedinOAuth2Constants {
+        AUTHORIZE_URI_TEMPLATE("https://www.linkedin.com/oauth/v2/authorization?client_id=%s&redirect_uri=%s&response_type=%s&scope=%s"),
+        RESPONSE_TYPE("code"),
+        RELAY_KEY("state"),
+        CLIENT_NAME("linkedin"),
+        HOST_LINKEDIN("www.linkedin.com"),
+        REQUIRED_SCOPES("r_basicprofile,r_emailaddress"),
+        SCOPE_DELIMITER(" "),
+        AUTHENTICATE_URI("https://www.linkedin.com/oauth/v2/accessToken"),
+        ACCESS_TOKEN("access_token"),
+        EXPIRES_IN("expires_in")
+        ;
+
+        private String constant;
+
+        LinkedinOAuth2Constants(String value) {
+            constant = value;
+        }
+
+        public String getValue() {
+            return constant;
+        }
+    }
+
+    protected enum LinkedinMeConstants {
+        ME_URI("https://api.linkedin.com/v2/me"),
+        ID("id"),
+        FIRST_NAME("firstName"),
+        LAST_NAME("lastName")
+        ;
+
+        private String constant;
+
+        LinkedinMeConstants(String value) {
+            constant = value;
+        }
+
+        public String getValue() {
+            return constant;
+        }
+    }
+
+    protected enum LinkedinErrorCodes {
+        ERROR("error"),
+        USER_CANCELLED_LOGIN("user_cancelled_login"),
+        USER_CANCELLED_AUTHORIZE("user_cancelled_authorize"),
+        ERROR_DESCRIPTION("error_description"),
+        DEFAULT_ERROR("default_error"),
+        SERVICE_ERROR_CODE("serviceErrorCode"),
+        ERROR_MESSAGE("message"),
+        ERROR_STATUS("status"),
+        SERVICE_ERROR_CODE_100("100"),
+        ERROR_MESSAGE_NOT_ENOUGH_PERM("Not enough permissions to access")
+        ;
+
+        private String constant;
+
+        LinkedinErrorCodes(String value) {
+            constant = value;
+        }
+
+        public String getValue() {
+            return constant;
+        }
+
+        public static LinkedinErrorCodes fromString(String value) {
+            for (LinkedinErrorCodes code : LinkedinErrorCodes.values()) {
+                if (code.getValue().equals(value)) {
+                    return code;
+                }
+            }
+            return LinkedinErrorCodes.DEFAULT_ERROR;
+        }
+    }
+
+    public LinkedinOAuth2Handler(Configuration config) {
+        super(config, LinkedinOAuth2Constants.CLIENT_NAME.getValue(), LinkedinOAuth2Constants.HOST_LINKEDIN.getValue());
+        authorizeUriTemplate = LinkedinOAuth2Constants.AUTHORIZE_URI_TEMPLATE.getValue();
+        requiredScopes = LinkedinOAuth2Constants.REQUIRED_SCOPES.getValue();
+        scopeDelimiter = LinkedinOAuth2Constants.SCOPE_DELIMITER.getValue();
+        relayKey = LinkedinOAuth2Constants.RELAY_KEY.getValue();
+        authenticateUri = LinkedinOAuth2Constants.AUTHENTICATE_URI.getValue();
+        dataSource.addImportClass(DataSourceType.oauth2contact.name(), LinkedinContactsImport.class.getCanonicalName());
+    }
+
+    @Override
+    protected void validateTokenResponse(JsonNode response) throws ServiceException {
+        if (response.has(LinkedinErrorCodes.ERROR.getValue())) {
+            final String error = response.get(LinkedinErrorCodes.ERROR.getValue()).asText();
+            final JsonNode errorMsg = response.get(LinkedinErrorCodes.ERROR_DESCRIPTION.getValue());
+            ZimbraLog.extensions.debug("Response from linkedin: %s", response.asText());
+            switch (LinkedinErrorCodes.fromString(StringUtils.upperCase(error))) {
+            case USER_CANCELLED_LOGIN:
+                ZimbraLog.extensions.info(
+                    "User cancelled on login screen : " + errorMsg);
+                throw ServiceException.OPERATION_DENIED(
+                    "User cancelled on login screen");
+            case USER_CANCELLED_AUTHORIZE:
+                ZimbraLog.extensions.info(
+                        "User cancelled to authorize : " + errorMsg);
+                    throw ServiceException.OPERATION_DENIED(
+                        "User cancelled to authorize");
+            case DEFAULT_ERROR:
+            default:
+                ZimbraLog.extensions
+                    .warn("Unexpected error while trying to validate token: " + errorMsg);
+                throw ServiceException.PERM_DENIED("Token validation failed");
+            }
+        }
+
+        // ensure the tokens we requested are present
+        if (!response.has(LinkedinOAuth2Constants.ACCESS_TOKEN.getValue()) || !response.has(LinkedinOAuth2Constants.EXPIRES_IN.getValue())) {
+            throw ServiceException.PARSE_ERROR("Unexpected response from social service.", null);
+        }
+    }
+
+    @Override
+    protected String getPrimaryEmail(JsonNode credentials, Account account) throws ServiceException {
+        JsonNode json = null;
+        final String basicToken = credentials.get(LinkedinOAuth2Constants.ACCESS_TOKEN.getValue()).asText();
+        final String url = LinkedinMeConstants.ME_URI.getValue();
+
+        try {
+            final GetMethod request = new GetMethod(url);
+            request.setRequestHeader(OAuth2HttpConstants.HEADER_CONTENT_TYPE.getValue(),
+                "application/x-www-form-urlencoded");
+            request.setRequestHeader(OAuth2HttpConstants.HEADER_ACCEPT.getValue(), "application/json");
+            request.setRequestHeader(OAuth2HttpConstants.HEADER_AUTHORIZATION.getValue(),
+                "Bearer " + basicToken);
+            json = executeRequestForJson(request);
+        } catch (final IOException e) {
+            ZimbraLog.extensions.warnQuietly("There was an issue acquiring the account details.",
+                    e);
+            throw ServiceException.FAILURE("There was an issue acquiring the account details.",
+                    null);
+        }
+        // check for errors
+        if (json.has(LinkedinErrorCodes.SERVICE_ERROR_CODE.getValue())
+                && json.has(LinkedinErrorCodes.ERROR_MESSAGE.getValue())) {
+            if (json.get(LinkedinErrorCodes.SERVICE_ERROR_CODE.getValue()).asText().equals(LinkedinErrorCodes.SERVICE_ERROR_CODE_100.getValue())
+                    && json.get(LinkedinErrorCodes.ERROR_MESSAGE.getValue()).asText().contains(LinkedinErrorCodes.ERROR_MESSAGE_NOT_ENOUGH_PERM.getValue())
+                    ) {
+                return account.getMail();
+            }
+            ZimbraLog.extensions.warnQuietly("Error occured while getting profile details."
+                    + " Code=" + json.get(LinkedinErrorCodes.SERVICE_ERROR_CODE.getValue())
+                    + ", Status=" + json.get(LinkedinErrorCodes.ERROR_STATUS.getValue())
+                    + ", ErrorMessage=" + json.get(LinkedinErrorCodes.ERROR_MESSAGE.getValue()),
+                    null);
+            throw ServiceException.FAILURE("Error occured while getting profile details.",
+                    null);
+        }
+        // no errors found
+        if (json.has(LinkedinMeConstants.FIRST_NAME.getValue()) && json.has(LinkedinMeConstants.LAST_NAME.getValue())
+                && !json.get(LinkedinMeConstants.FIRST_NAME.getValue()).asText().isEmpty()
+                && !json.get(LinkedinMeConstants.LAST_NAME.getValue()).asText().isEmpty()) {
+            return json.get(LinkedinMeConstants.FIRST_NAME.getValue()).asText() + "." + json.get(LinkedinMeConstants.LAST_NAME.getValue()).asText();
+        } else if (json.has(LinkedinMeConstants.ID.getValue()) && !json.get(LinkedinMeConstants.ID.getValue()).asText().isEmpty()) {
+            return json.get(LinkedinMeConstants.ID.getValue()).asText();
+        }
+
+        // if we couldn't retrieve the user first & last name, the response from
+        // downstream is missing data
+        // this could be the result of a misconfigured application id/secret
+        // (not enough scopes)
+        ZimbraLog.extensions.error("The user id could not be retrieved from the social service api.");
+        throw ServiceException.UNSUPPORTED();
+    }
+
+    @Override
+    public Boolean authenticate(OAuthInfo oauthInfo) throws ServiceException {
+        final Account account = oauthInfo.getAccount();
+        final String clientId = config.getString(
+            String.format(OAuth2ConfigConstants.LC_OAUTH_CLIENT_ID_TEMPLATE.getValue(), client), client,
+            account);
+        final String clientSecret = config.getString(
+            String.format(OAuth2ConfigConstants.LC_OAUTH_CLIENT_SECRET_TEMPLATE.getValue(), client),
+            client, account);
+        final String clientRedirectUri = config.getString(
+            String.format(OAuth2ConfigConstants.LC_OAUTH_CLIENT_REDIRECT_URI_TEMPLATE.getValue(), client),
+            client, account);
+        if (StringUtils.isEmpty(clientId) || StringUtils.isEmpty(clientSecret)
+            || StringUtils.isEmpty(clientRedirectUri)) {
+            throw ServiceException.FAILURE("Required config(id, secret and redirectUri) parameters are not provided.", null);
+        }
+        final String basicToken = OAuth2Utilities.encodeBasicHeader(clientId, clientSecret);
+        // set client specific properties
+        oauthInfo.setClientId(clientId);
+        oauthInfo.setClientSecret(clientSecret);
+        oauthInfo.setClientRedirectUri(clientRedirectUri);
+        oauthInfo.setTokenUrl(authenticateUri);
+        // request credentials from social service
+        final JsonNode credentials = getTokenRequest(oauthInfo, basicToken);
+        // ensure the response contains the necessary credentials
+        validateTokenResponse(credentials);
+        // determine account associated with credentials
+        final String username = getPrimaryEmail(credentials, account);
+        ZimbraLog.extensions.trace("Authentication performed for:" + username);
+
+        // get zimbra mailbox
+        final ZMailbox mailbox = getZimbraMailbox(oauthInfo.getZmAuthToken());
+
+        // store refreshToken
+        oauthInfo.setUsername(username);
+        oauthInfo.setRefreshToken(credentials.get(LinkedinOAuth2Constants.ACCESS_TOKEN.getValue()).asText());
+        dataSource.syncDatasource(mailbox, oauthInfo, null);
+        return true;
+    }
+
+}

--- a/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
@@ -60,6 +60,21 @@ import com.zimbra.oauth.utilities.OAuth2Utilities;
  * @copyright Copyright © 2018
  */
 public abstract class OAuth2Handler {
+    // for relay encoding
+    public enum RelayEnum {
+        RELAY("relay"),
+        TYPE("type"),
+        JWT("jwt");
+
+        String name;
+        RelayEnum(String name) {
+            this.name = name;
+        }
+
+        public String getValue() {
+            return this.name;
+        }
+    }
 
     public static final String RELAY_DELIMETER = ";";
     /**
@@ -277,7 +292,7 @@ public abstract class OAuth2Handler {
                 if (relayValue.isEmpty()) {
                     relayValue = "&" + relayKey + "=";
                 }
-                relayValue += RELAY_DELIMETER
+                relayValue += URLEncoder.encode(RELAY_DELIMETER, OAuth2Constants.ENCODING.getValue())
                     + URLEncoder.encode(type, OAuth2Constants.ENCODING.getValue());
             } catch (final UnsupportedEncodingException e) {
                 throw ServiceException.INVALID_REQUEST("Unable to encode type parameter.", e);
@@ -290,7 +305,7 @@ public abstract class OAuth2Handler {
         // jwt is third and optional
         if (!jwt.isEmpty()) {
             try {
-                relayValue += RELAY_DELIMETER
+                relayValue += URLEncoder.encode(RELAY_DELIMETER, OAuth2Constants.ENCODING.getValue())
                     + URLEncoder.encode(jwt, OAuth2Constants.ENCODING.getValue());
             } catch (final UnsupportedEncodingException e) {
                 throw ServiceException.INVALID_REQUEST("Unable to encode jwt parameter.", e);

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
@@ -84,11 +84,11 @@ public class OAuth2ResourceUtilities {
         try {
             // verify params
             oauth2Handler.verifyAuthorizeParams(paramsForAuthorize);
-            if (isJWT(authToken)) {
-                // if our credential is a jwt, pass it along too
-                paramsForAuthorize.put(OAuth2HttpConstants.JWT_PARAM_KEY.getValue(),
-                    authToken.getEncoded());
-            }
+//            if (isJWT(authToken)) {
+//                // if our credential is a jwt, pass it along too
+//                paramsForAuthorize.put(OAuth2HttpConstants.JWT_PARAM_KEY.getValue(),
+//                    authToken.getEncoded());
+//            }
             return oauth2Handler.authorize(paramsForAuthorize, account);
         } catch (final ServiceException e) {
             // return redirect error if invalid request
@@ -99,9 +99,9 @@ public class OAuth2ResourceUtilities {
             }
             // otherwise bubble error
             throw e;
-        } catch (final AuthTokenException e) {
-            throw ServiceException
-                .PERM_DENIED(OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE.getValue());
+//        } catch (final AuthTokenException e) {
+//            throw ServiceException
+//                .PERM_DENIED(OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE.getValue());
         }
     }
 
@@ -223,9 +223,9 @@ public class OAuth2ResourceUtilities {
                     relay = decodedUrl;
                 }
             } catch (final UnsupportedEncodingException e) {
-                ZimbraLog.extensions.info("Unable to decode relay parameter.");
+                ZimbraLog.extensions.info("Unable to decode relay parameter. URI=" + url);
             } catch (final URISyntaxException e) {
-                ZimbraLog.extensions.info("Invalid relay URI syntax found.");
+                ZimbraLog.extensions.info("Invalid relay URI syntax found. URI=" + url);
             }
         }
         return relay;

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ResourceUtilities.java
@@ -84,11 +84,11 @@ public class OAuth2ResourceUtilities {
         try {
             // verify params
             oauth2Handler.verifyAuthorizeParams(paramsForAuthorize);
-//            if (isJWT(authToken)) {
-//                // if our credential is a jwt, pass it along too
-//                paramsForAuthorize.put(OAuth2HttpConstants.JWT_PARAM_KEY.getValue(),
-//                    authToken.getEncoded());
-//            }
+            if (isJWT(authToken)) {
+                // if our credential is a jwt, pass it along too
+                paramsForAuthorize.put(OAuth2HttpConstants.JWT_PARAM_KEY.getValue(),
+                    authToken.getEncoded());
+            }
             return oauth2Handler.authorize(paramsForAuthorize, account);
         } catch (final ServiceException e) {
             // return redirect error if invalid request
@@ -99,9 +99,9 @@ public class OAuth2ResourceUtilities {
             }
             // otherwise bubble error
             throw e;
-//        } catch (final AuthTokenException e) {
-//            throw ServiceException
-//                .PERM_DENIED(OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE.getValue());
+        } catch (final AuthTokenException e) {
+            throw ServiceException
+                .PERM_DENIED(OAuth2ErrorConstants.ERROR_INVALID_ZM_AUTH_CODE.getValue());
         }
     }
 


### PR DESCRIPTION
Problem/Task: create datasource implementation for Linkedin contacts sync using oAuth2

Fix:
1. Authorize and authenticate using oAuth2 rest api provided by Linkedin
2. Folder created is with name as <username>-contact-linkedin, as profile call for linkedin needs "r_fullprofile" permission and this permission in given by linkedin on request. Request with linkedin support is raised. 

Testing done:
1. Contact folder and datasource is created in user account.
2. Tested functionality manually.
```
zmprov gds cp1
# name cp1@cpathak.zdev.local-contact-linkedin
# type oauth2contact
objectClass: zimbraDataSource
zimbraCreateTimestamp: 20180724133602.672Z
zimbraDataSourceConnectionType: cleartext
zimbraDataSourceEnabled: TRUE
zimbraDataSourceFolderId: 60020
zimbraDataSourceHost: www.linkedin.com
zimbraDataSourceId: 54e84c2e-50e5-405f-aa60-9c008d41aac0
zimbraDataSourceImportClassName: com.zimbra.oauth.handlers.impl.LinkedinContactsImport
zimbraDataSourceImportOnly: FALSE
zimbraDataSourceName: cp1@cpathak.zdev.local-contact-linkedin
zimbraDataSourceOAuthRefreshToken: VALUE-BLOCKED
zimbraDataSourcePollingInterval: 1d
zimbraDataSourceType: oauth2contact
```

Testing needs to be done by QA:
1. go to https://www.linkedin.com/developer/apps
2. create app from - my apps -> create app
3. select default app permissions "r_basicprofile" and "r_emailaddress"
4. add "https://<your_host_name>/service/extension/oauth2/authenticate/linkedin" OAuth 2.0 authorized redirect url 
5. set zimbraOAuthConsumerRedirectUri: https://cpathak.zdev.local/service/extension/oauth2/authenticate/linkedin:linkedin
6. set zimbraOAuthConsumerCredentials: <app_client_id>:<app_client_secret>:linkedin
7. Make sure, Authorization and Authentication is done using oAuth2
8. Make sure, contacts folder and datasource is created as mentioned above