### PR TITLE
ZCS-5599 Use request account's soap service uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ This service's configuration can all be found in Zimbra's `localconfig.xml` file
 
 | Key | Description | Optional | Example Options |
 | --- | ----------- | -------- | --------------- |
-| host_uri_template | The host uri to connect via ZMailbox | Yes | `https://%s:443` |
 | zm_oauth_classes_handlers_yahoo<sup>1</sup> | The handler implementation class for the client | | `com.zimbra.oauth.handlers.impl.YahooOAuth2Handler` |
 
 <sup>1</sup>Replace the `yahoo` part of the key name with the name of the client (e.g. `yahoo`, `google`, `outlook`).

--- a/src/java-test/com/zimbra/oauth/handlers/impl/FacebookOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/FacebookOAuth2HandlerTest.java
@@ -85,11 +85,6 @@ public class FacebookOAuth2HandlerTest {
     protected final String clientSecret = "test-secret";
 
     /**
-     * Hostname for testing.
-     */
-    protected final String hostname = "localhost";
-
-    /**
      * Redirect URI for testing.
      */
     protected final String clientRedirectUri = "http://localhost/oauth2/authenticate";
@@ -129,11 +124,6 @@ public class FacebookOAuth2HandlerTest {
     public void testFacebookOAuth2Handler() throws Exception {
         final OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_HOST_URI_TEMPLATE.getValue(),
-            OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue()))
-                .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue());
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_ZIMBRA_SERVER_HOSTNAME.getValue()))
-            .andReturn(hostname);
         PowerMock.mockStatic(OAuth2DataSource.class);
         expect(OAuth2DataSource.createDataSource(FacebookOAuth2Constants.CLIENT_NAME.getValue(),
             FacebookOAuth2Constants.HOST_FACEBOOK.getValue())).andReturn(mockDataSource);
@@ -215,7 +205,8 @@ public class FacebookOAuth2HandlerTest {
                 FacebookOAuth2Constants.CLIENT_NAME.getValue())),
             matches(FacebookOAuth2Constants.CLIENT_NAME.getValue()), anyObject()))
                 .andReturn(clientRedirectUri);
-        expect(handler.getZimbraMailbox(anyObject(AuthToken.class))).andReturn(mockZMailbox);
+        expect(handler.getZimbraMailbox(anyObject(AuthToken.class), anyObject(Account.class)))
+            .andReturn(mockZMailbox);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
             .andReturn(mockCredentials);
         handler.validateTokenResponse(anyObject(JsonNode.class));

--- a/src/java-test/com/zimbra/oauth/handlers/impl/GoogleOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/GoogleOAuth2HandlerTest.java
@@ -84,11 +84,6 @@ public class GoogleOAuth2HandlerTest {
     protected final String clientSecret = "test-secret";
 
     /**
-     * Hostname for testing.
-     */
-    protected final String hostname = "localhost";
-
-    /**
      * Redirect URI for testing.
      */
     protected final String clientRedirectUri = "http://localhost/oauth2/authenticate";
@@ -128,11 +123,6 @@ public class GoogleOAuth2HandlerTest {
     public void testGoogleOAuth2Handler() throws Exception {
         final OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_HOST_URI_TEMPLATE.getValue(),
-            OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue()))
-                .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue());
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_ZIMBRA_SERVER_HOSTNAME.getValue()))
-            .andReturn(hostname);
         PowerMock.mockStatic(OAuth2DataSource.class);
         expect(OAuth2DataSource.createDataSource(GoogleOAuth2Constants.CLIENT_NAME.getValue(),
             GoogleOAuth2Constants.HOST_GOOGLE.getValue())).andReturn(mockDataSource);
@@ -215,7 +205,8 @@ public class GoogleOAuth2HandlerTest {
             matches(GoogleOAuth2Constants.CLIENT_NAME.getValue()), anyObject()))
                 .andReturn(clientRedirectUri);
         expect(handler.getDatasourceCustomAttrs(anyObject())).andReturn(customAttrs);
-        expect(handler.getZimbraMailbox(anyObject(AuthToken.class))).andReturn(mockZMailbox);
+        expect(handler.getZimbraMailbox(anyObject(AuthToken.class), anyObject(Account.class)))
+            .andReturn(mockZMailbox);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
             .andReturn(mockCredentials);
         handler.validateTokenResponse(anyObject());

--- a/src/java-test/com/zimbra/oauth/handlers/impl/OutlookOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/OutlookOAuth2HandlerTest.java
@@ -84,11 +84,6 @@ public class OutlookOAuth2HandlerTest {
     protected final String clientSecret = "test-secret";
 
     /**
-     * Hostname for testing.
-     */
-    protected final String hostname = "localhost";
-
-    /**
      * Redirect URI for testing.
      */
     protected final String clientRedirectUri = "http://localhost/oauth2/authenticate";
@@ -128,11 +123,6 @@ public class OutlookOAuth2HandlerTest {
     public void testOutlookOAuth2Handler() throws Exception {
         final OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_HOST_URI_TEMPLATE.getValue(),
-            OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue()))
-                .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue());
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_ZIMBRA_SERVER_HOSTNAME.getValue()))
-            .andReturn(hostname);
         PowerMock.mockStatic(OAuth2DataSource.class);
         expect(OAuth2DataSource.createDataSource(OutlookOAuth2Constants.CLIENT_NAME.getValue(),
             OutlookOAuth2Constants.HOST_OUTLOOK.getValue())).andReturn(mockDataSource);
@@ -213,7 +203,8 @@ public class OutlookOAuth2HandlerTest {
                 OutlookOAuth2Constants.CLIENT_NAME.getValue())),
             matches(OutlookOAuth2Constants.CLIENT_NAME.getValue()), anyObject()))
                 .andReturn(clientRedirectUri);
-        expect(handler.getZimbraMailbox(anyObject(AuthToken.class))).andReturn(mockZMailbox);
+        expect(handler.getZimbraMailbox(anyObject(AuthToken.class), anyObject(Account.class)))
+            .andReturn(mockZMailbox);
         expect(handler.getDatasourceCustomAttrs(anyObject())).andReturn(null);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
             .andReturn(mockCredentials);

--- a/src/java-test/com/zimbra/oauth/handlers/impl/YahooOAuth2HandlerTest.java
+++ b/src/java-test/com/zimbra/oauth/handlers/impl/YahooOAuth2HandlerTest.java
@@ -85,11 +85,6 @@ public class YahooOAuth2HandlerTest {
     protected final String clientSecret = "test-secret";
 
     /**
-     * Hostname for testing.
-     */
-    protected final String hostname = "localhost";
-
-    /**
      * Redirect URI for testing.
      */
     protected final String clientRedirectUri = "http://localhost/oauth2/authenticate";
@@ -125,11 +120,6 @@ public class YahooOAuth2HandlerTest {
     public void testYahooOAuth2Handler() throws Exception {
         final OAuth2DataSource mockDataSource = EasyMock.createMock(OAuth2DataSource.class);
 
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_HOST_URI_TEMPLATE.getValue(),
-            OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue()))
-                .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue());
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_ZIMBRA_SERVER_HOSTNAME.getValue()))
-            .andReturn(hostname);
         PowerMock.mockStatic(OAuth2DataSource.class);
         expect(OAuth2DataSource.createDataSource(YahooOAuth2Constants.CLIENT_NAME.getValue(),
             ZDataSource.SOURCE_HOST_YAHOO)).andReturn(mockDataSource);
@@ -209,7 +199,8 @@ public class YahooOAuth2HandlerTest {
                 YahooOAuth2Constants.CLIENT_NAME.getValue())),
             matches(YahooOAuth2Constants.CLIENT_NAME.getValue()), anyObject()))
                 .andReturn(clientRedirectUri);
-        expect(handler.getZimbraMailbox(anyObject(AuthToken.class))).andReturn(mockZMailbox);
+        expect(handler.getZimbraMailbox(anyObject(AuthToken.class), anyObject(Account.class)))
+            .andReturn(mockZMailbox);
         expect(handler.getDatasourceCustomAttrs(anyObject())).andReturn(null);
         expect(OAuth2Handler.getTokenRequest(anyObject(OAuthInfo.class), anyObject(String.class)))
             .andReturn(mockCredentials);

--- a/src/java-test/com/zimbra/oauth/managers/ClassManagerTest.java
+++ b/src/java-test/com/zimbra/oauth/managers/ClassManagerTest.java
@@ -42,7 +42,6 @@ import com.zimbra.oauth.handlers.IOAuth2Handler;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.LdapConfiguration;
 import com.zimbra.oauth.utilities.OAuth2ConfigConstants;
-import com.zimbra.oauth.utilities.OAuth2Constants;
 
 /**
  * Test class for {@link ClassManager}.
@@ -65,11 +64,6 @@ public class ClassManagerTest {
      * Test client.
      */
     protected final String client = "yahoo";
-
-    /**
-     * Test hostname.
-     */
-    protected static final String hostname = "zcs-dev.test";
 
     /**
      * Setup for tests.
@@ -99,11 +93,6 @@ public class ClassManagerTest {
         PowerMock.expectLastCall().andReturn(mockConfig);
         expect(mockConfig.getString(matches(OAuth2ConfigConstants.LC_HANDLER_CLASS_PREFIX.getValue() + client)))
             .andReturn("com.zimbra.oauth.handlers.impl.YahooOAuth2Handler");
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_ZIMBRA_SERVER_HOSTNAME.getValue()))
-            .andReturn(hostname);
-        expect(mockConfig.getString(OAuth2ConfigConstants.LC_HOST_URI_TEMPLATE.getValue(),
-            OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue()))
-                .andReturn(OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue());
 
         PowerMock.replay(LdapConfiguration.class);
         replay(mockConfig);

--- a/src/java/com/zimbra/oauth/handlers/impl/FacebookOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/FacebookOAuth2Handler.java
@@ -339,7 +339,7 @@ public class FacebookOAuth2Handler extends OAuth2Handler implements IOAuth2Handl
         ZimbraLog.extensions.trace("Authentication performed for:" + username);
 
         // get zimbra mailbox
-        final ZMailbox mailbox = getZimbraMailbox(oauthInfo.getZmAuthToken());
+        final ZMailbox mailbox = getZimbraMailbox(oauthInfo.getZmAuthToken(), account);
 
         // store refreshToken
         oauthInfo.setUsername(username);

--- a/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OAuth2Handler.java
@@ -40,9 +40,8 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
-import com.zimbra.cs.account.Provisioning;
-import com.zimbra.cs.account.Server;
 import com.zimbra.cs.account.ZimbraAuthToken;
+import com.zimbra.cs.util.AccountUtil;
 import com.zimbra.oauth.handlers.IOAuth2Handler;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
@@ -487,7 +486,7 @@ public abstract class OAuth2Handler {
 
     /**
      * Retrieves the Zimbra mailbox via specified auth token.<br>
-     * Uses the account's zimbraServiceHostname in the soap uri.
+     * Fetches the soap uri for the specified account.
      *
      * @param zmAuthToken The Zimbra auth token to identify the account with
      * @param account Instance of the account we want a mailbox for
@@ -498,16 +497,12 @@ public abstract class OAuth2Handler {
     protected ZMailbox getZimbraMailbox(AuthToken zmAuthToken, Account account) throws ServiceException {
         // create a mailbox by auth token
         try {
-            // use the serviceHostname for the account for multi-node envs
-            final Server server = Provisioning.getInstance().getServer(account);
-            final String zimbraHostname = server.getAttr(Provisioning.A_zimbraServiceHostname);
-            final String hostUri = String
-                .format(config.getString(OAuth2ConfigConstants.LC_HOST_URI_TEMPLATE.getValue(),
-                    OAuth2Constants.DEFAULT_HOST_URI_TEMPLATE.getValue()), zimbraHostname);
-            ZimbraLog.extensions.debug("Creating ZMailbox for account: %s, host uri: %s",
-                account.getName(), hostUri);
+            // fetch soap uri via the account for multi-node envs
+            final String zimbraSoapUri = AccountUtil.getSoapUri(account);
+            ZimbraLog.extensions.debug("Creating ZMailbox for account: %s, soap uri: %s",
+                account.getName(), zimbraSoapUri);
             final Options options = new Options();
-            options.setUri(hostUri);
+            options.setUri(zimbraSoapUri);
             final ZMailbox mbox = new ZMailbox(options);
             // get a csrf unsecured token since we are internal
             final AuthToken csrfUnsafeToken = ZimbraAuthToken

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ConfigConstants.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ConfigConstants.java
@@ -28,7 +28,6 @@ package com.zimbra.oauth.utilities;
 public enum OAuth2ConfigConstants {
 
     LC_HANDLER_CLASS_PREFIX("zm_oauth_classes_handlers_"),
-    LC_HOST_URI_TEMPLATE("host_uri_template"),
 
     LC_OAUTH_CLIENT_ID_TEMPLATE("zm_oauth_%s_client_id"),
     LC_OAUTH_CLIENT_SECRET_TEMPLATE("zm_oauth_%s_client_secret"),

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ConfigConstants.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ConfigConstants.java
@@ -27,9 +27,7 @@ package com.zimbra.oauth.utilities;
  */
 public enum OAuth2ConfigConstants {
 
-    LC_ZIMBRA_SERVER_HOSTNAME("zimbra_server_hostname"),
     LC_HANDLER_CLASS_PREFIX("zm_oauth_classes_handlers_"),
-    LC_SOAP_HOST("soap_host"),
     LC_HOST_URI_TEMPLATE("host_uri_template"),
 
     LC_OAUTH_CLIENT_ID_TEMPLATE("zm_oauth_%s_client_id"),


### PR DESCRIPTION
* Fetch soap service uri from account for ZMailbox creation to resolve multi-node env issue.

Tested in aws and local for mutli and single.