### PR TITLE
ZCS-7167 Fix http entity reading before request closure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ See the [client setup wiki].
 
 | Client | Required scopes string |
 | ------ | ---------------------- |
-| Google | `https://www.googleapis.com/auth/contacts.readonly+profile:google_contact` |
+| Google Contact | `https://www.googleapis.com/auth/contacts.readonly+profile:google_contact` |
+| Google CalDav | `https://www.googleapis.com/auth/calendar:google_caldav` |
 | Facebook | `user_friends,read_custom_friendlists,email,user_location,public_profile,user_about_me,user_birthday,groups_access_member_info:facebook_contact` |
 
 Note: Delimiters can vary across clients.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See the [client setup wiki].
 
 | Client | Required scopes string |
 | ------ | ---------------------- |
-| Google | `https://www.googleapis.com/auth/contacts profile:google_contact` |
+| Google | `https://www.googleapis.com/auth/contacts.readonly+profile:google_contact` |
 | Facebook | `user_friends,read_custom_friendlists,email,user_location,public_profile,user_about_me,user_birthday,groups_access_member_info:facebook_contact` |
 
 Note: Delimiters can vary across clients.

--- a/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/GoogleContactsImport.java
@@ -83,7 +83,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.xml.sax.SAXException;
@@ -104,6 +103,7 @@ import com.zimbra.cs.service.mail.CreateContact;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleContactConstants;
 import com.zimbra.oauth.handlers.impl.GoogleOAuth2Handler.GoogleOAuth2Constants;
+import com.zimbra.oauth.models.HttpResponseWrapper;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.LdapConfiguration;
@@ -780,7 +780,7 @@ public class GoogleContactsImport implements DataImport {
                         try {
                             // fetch the image
                             final HttpGet get = new HttpGet(imageUrl);
-                            final HttpResponse response = OAuth2Utilities.executeRequestRaw(get);
+                            final HttpResponseWrapper response = OAuth2Utilities.executeRequestRaw(get);
                             String imageNum = "";
                             if (i > 1) {
                                 imageNum = String.valueOf(i++);

--- a/src/java/com/zimbra/oauth/handlers/impl/OutlookContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/OutlookContactsImport.java
@@ -64,7 +64,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 
@@ -89,6 +88,7 @@ import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.oauth.handlers.impl.OutlookContactsImport.OutlookContactsUtil.OContactFieldType;
 import com.zimbra.oauth.handlers.impl.OutlookOAuth2Handler.OutlookContactConstants;
 import com.zimbra.oauth.handlers.impl.OutlookOAuth2Handler.OutlookOAuth2Constants;
+import com.zimbra.oauth.models.HttpResponseWrapper;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.LdapConfiguration;
@@ -681,7 +681,7 @@ public class OutlookContactsImport implements DataImport {
                 // use authorization
                 get.addHeader(OAuth2HttpConstants.HEADER_AUTHORIZATION.getValue(),
                     authorizationHeader);
-                final HttpResponse response = OAuth2Utilities.executeRequestRaw(client, get);
+                final HttpResponseWrapper response = OAuth2Utilities.executeRequestRaw(client, get);
                 // add to attachments
                 final Attachment attachment = OAuth2Utilities.createAttachmentFromResponse(
                     response,

--- a/src/java/com/zimbra/oauth/handlers/impl/TwitterOAuth2Handler.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/TwitterOAuth2Handler.java
@@ -38,7 +38,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
@@ -51,6 +50,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.account.Account;
 import com.zimbra.oauth.handlers.IOAuth2Handler;
+import com.zimbra.oauth.models.HttpResponseWrapper;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.OAuth2Constants;
@@ -387,7 +387,7 @@ public class TwitterOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
             authorizationHeader);
         String responseParams = null;
         try {
-            final HttpResponse response = OAuth2Utilities.executeRequestRaw(request);
+            final HttpResponseWrapper response = OAuth2Utilities.executeRequestRaw(request);
             responseParams = validateTwitterResponse(response);
         } catch (final IOException e) {
             ZimbraLog.extensions
@@ -417,7 +417,7 @@ public class TwitterOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
             authorizationHeader);
         String rawResponse = null;
         try {
-            final HttpResponse response = OAuth2Utilities.executeRequestRaw(request);
+            final HttpResponseWrapper response = OAuth2Utilities.executeRequestRaw(request);
             rawResponse = validateTwitterResponse(response);
             ZimbraLog.extensions.debug("Request for auth token completed.");
         } catch (final IOException e) {
@@ -438,14 +438,14 @@ public class TwitterOAuth2Handler extends OAuth2Handler implements IOAuth2Handle
      * @throws ServiceException If there was an issue with the response (non OK status)
      * @throws IOException If there are issues parsing the response (non OK status or otherwise)
      */
-    protected String validateTwitterResponse(HttpResponse response)
+    protected String validateTwitterResponse(HttpResponseWrapper responseWrapper)
         throws ServiceException, IOException {
         String rawResponse = null;
         // always get the body if available
-        final HttpEntity entity = response.getEntity();
-        if (entity != null) {
-            rawResponse = new String(
-                OAuth2Utilities.decodeStream(entity.getContent(), entity.getContentLength()));
+        final HttpResponse response = responseWrapper.getResponse();
+        final byte[] entityBytes = responseWrapper.getEntityBytes();
+        if (entityBytes != null) {
+            rawResponse = new String(entityBytes);
         }
         // check for known errors if the status is not ok
         if (HttpStatus.SC_OK != response.getStatusLine().getStatusCode()) {

--- a/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
+++ b/src/java/com/zimbra/oauth/handlers/impl/YahooContactsImport.java
@@ -70,7 +70,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -87,6 +86,7 @@ import com.zimbra.cs.service.mail.CreateContact;
 import com.zimbra.cs.service.util.ItemId;
 import com.zimbra.oauth.handlers.impl.YahooOAuth2Handler.YahooContactConstants;
 import com.zimbra.oauth.handlers.impl.YahooOAuth2Handler.YahooOAuth2Constants;
+import com.zimbra.oauth.models.HttpResponseWrapper;
 import com.zimbra.oauth.models.OAuthInfo;
 import com.zimbra.oauth.utilities.Configuration;
 import com.zimbra.oauth.utilities.LdapConfiguration;
@@ -577,7 +577,8 @@ public class YahooContactsImport implements DataImport {
                         try {
                             // fetch the image
                             final HttpGet get = new HttpGet(imageUrl);
-                            final HttpResponse response = OAuth2Utilities.executeRequestRaw(get);
+                            final HttpResponseWrapper response = OAuth2Utilities
+                                .executeRequestRaw(get);
                             // add to attachments
                             final Attachment attachment = OAuth2Utilities
                                 .createAttachmentFromResponse(response, key,

--- a/src/java/com/zimbra/oauth/models/HttpResponseWrapper.java
+++ b/src/java/com/zimbra/oauth/models/HttpResponseWrapper.java
@@ -1,0 +1,80 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra OAuth Social Extension
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.oauth.models;
+
+import org.apache.http.HttpResponse;
+
+/**
+ * The HttpResponseWrapper class.<br>
+ * Wrapper for HttpResponse contains entity as byte array.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.oauth.models
+ * @copyright Copyright © 2019
+ */
+public class HttpResponseWrapper {
+
+    /**
+     * The http response.
+     */
+    protected HttpResponse response;
+
+    /**
+     * The http entity.
+     */
+    protected byte[] entityBytes;
+
+    /**
+     * Creates an instance with response and entity.
+     *
+     * @param response The response to set
+     * @param entityBytes The entity bytes to set
+     */
+    public HttpResponseWrapper(HttpResponse response, byte[] entityBytes) {
+        this.response = response;
+        this.entityBytes = entityBytes;
+    }
+
+    /**
+     * @return the response
+     */
+    public HttpResponse getResponse() {
+        return response;
+    }
+
+    /**
+     * @param response the response to set
+     */
+    public void setResponse(HttpResponse response) {
+        this.response = response;
+    }
+
+    /**
+     * @return the entity bytes
+     */
+    public byte[] getEntityBytes() {
+        return entityBytes;
+    }
+
+    /**
+     * @param entityBytes the entity to set
+     */
+    public void setEntityBytes(byte[] entityBytes) {
+        this.entityBytes = entityBytes;
+    }
+
+}

--- a/src/java/com/zimbra/oauth/utilities/CalDavOAuth2Client.java
+++ b/src/java/com/zimbra/oauth/utilities/CalDavOAuth2Client.java
@@ -18,19 +18,11 @@
 package com.zimbra.oauth.utilities;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
-import org.apache.http.Consts;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.AuthSchemes;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.params.AuthPolicy;
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.impl.auth.BasicSchemeFactory;
 
 import com.zimbra.common.httpclient.HttpClientUtil;
 import com.zimbra.cs.dav.DavContext.Depth;
@@ -57,9 +49,6 @@ public class CalDavOAuth2Client extends CalDavClient {
 
     @Override
     protected HttpResponse executeMethod(HttpRequestBase m, Depth d, String bodyForLogging) throws IOException, HttpException {
-        final Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-            .register(AuthSchemes.BASIC, new BasicSchemeFactory(Consts.UTF_8)).build();
-        mClient.setDefaultAuthSchemeRegistry(authSchemeRegistry);
         final HttpClient client = mClient.build();
         m.setHeader("User-Agent", mUserAgent);
         String depth = "0";
@@ -75,9 +64,8 @@ public class CalDavOAuth2Client extends CalDavClient {
         default:
             break;
         }
-        m.setHeader("Depth", depth);
         final String authorizationHeader = String.format("Bearer %s", accessToken);
-        m.addHeader(OAuth2HttpConstants.HEADER_AUTHORIZATION.getValue(), authorizationHeader);
+        m.setHeader(OAuth2HttpConstants.HEADER_AUTHORIZATION.getValue(), authorizationHeader);
         m.setHeader("Depth", depth);
         logRequestInfo(m, bodyForLogging);
         final HttpResponse response = HttpClientUtil.executeMethod(client, m);


### PR DESCRIPTION
* Fix an issue where pre-emptively closing the request connection in `executeRequestRaw` prevents completion of entity stream read in subsequent methods - resulting in truncated chunk exception.
  * Read entity before closing request then use http response wrapper to store raw closed response and entity bytes where appropriate
  * Use improved `EntityUtils` for entity read
* Removed some unnecessary config from caldav client
* Updated readme with some missing/outdated config (no user facing change)

**Testing Done**
Tested contact import on vm003/011 with outlook and google (including caldav for google)

**Testing to be Done by QA**
See jira. Cal sync, other clients etc.