### PR TITLE
ZCS-8011: Third party vulnerabilities in Jackson databind

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -26,9 +26,9 @@
     <delete dir="${extension.deploy.dir}"/>
     <mkdir dir="${extension.deploy.dir}"/>
     <ivy:install organisation="com.auth0" module="java-jwt" revision="3.2.0" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-annotations" revision="2.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-core" revision="2.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar"/>
-    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-databind" revision="2.9.2" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-annotations" revision="2.10.1" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-core" revision="2.10.1" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar"/>
+    <ivy:install organisation="com.fasterxml.jackson.core" module="jackson-databind" revision="2.10.1" settingsRef="dev.settings" from="chain-resolver" to="build-dist" overwrite="true" transitive="true" type="jar"/>
     <echo> Copying ${build.dir}/${jar.file} and ${dist.dir}/*.jar to ${extension.deploy.dir}</echo>
     <copy todir="${extension.deploy.dir}">
       <fileset dir="${build.dir}" includes="${jar.file}" />


### PR DESCRIPTION
Issue: Third party vulnerabilities in Jackson library
Fix: Upgrade the Jackson library to the latest version

Related PRs:
https://github.com/Zimbra/zm-mailbox/pull/984
https://github.com/Zimbra/zm-zcs-lib/pull/59
https://github.com/Zimbra/zm-gql/pull/54
https://github.com/Zimbra/zm-gql-admin/pull/1
https://github.com/Zimbra/zm-network-gql/pull/5