### PR TITLE
ZCS-8911 Allow HTTP Patch proxying.

### DIFF
--- a/eclipse-ivysettings.xml
+++ b/eclipse-ivysettings.xml
@@ -3,6 +3,7 @@
 <property name="httpclient.version" value="4.5.8"/>
 <property name="httpclient.httpcore.version" value="4.4.11"/>
 <property name="httpclient.async.version" value="4.1.4"/>
+<property name="dom4j.version" value="2.1.1"/>
 <settings defaultResolver="chain-resolver" />
   <caches defaultCacheDir="${user.home}/.ivy2/cache" />
   <resolvers>

--- a/src/java/com/zimbra/oauth/resources/ZOAuth2ProxyServlet.java
+++ b/src/java/com/zimbra/oauth/resources/ZOAuth2ProxyServlet.java
@@ -86,6 +86,12 @@ public class ZOAuth2ProxyServlet extends ExtensionHttpHandler {
         doProxy(req, resp);
     }
 
+    @Override
+    public void doPatch(HttpServletRequest req, HttpServletResponse resp)
+        throws IOException, ServletException {
+        doProxy(req, resp);
+    }
+
     protected void doProxy(HttpServletRequest req, HttpServletResponse resp)
         throws IOException, ServletException {
         final String path = StringUtils.removeEndIgnoreCase(req.getPathInfo(), "/");

--- a/src/java/com/zimbra/oauth/utilities/OAuth2ProxyUtilities.java
+++ b/src/java/com/zimbra/oauth/utilities/OAuth2ProxyUtilities.java
@@ -36,6 +36,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -182,18 +183,24 @@ public class OAuth2ProxyUtilities {
                 method = new HttpGet(target);
             } else if (reqMethod.equalsIgnoreCase("POST")) {
                 final HttpPost post = new HttpPost(target);
-                if (body != null) {
+                if (body.length > 0) {
                     post.setEntity(buildEntity(body, req.getContentType()));
                 }
                 method = post;
             } else if (reqMethod.equalsIgnoreCase("PUT")) {
                 final HttpPut put = new HttpPut(target);
-                if (body != null) {
+                if (body.length > 0) {
                     put.setEntity(buildEntity(body, req.getContentType()));
                 }
                 method = put;
             } else if (reqMethod.equalsIgnoreCase("DELETE")) {
                 method = new HttpDelete(target);
+            } else if (reqMethod.equalsIgnoreCase("PATCH")) {
+                final HttpPatch patch = new HttpPatch(target);
+                if (body.length > 0) {
+                    patch.setEntity(buildEntity(body, req.getContentType()));
+                }
+                method = patch;
             } else {
                 ZimbraLog.extensions.info("unsupported request method: " + reqMethod);
                 sendError(resp, HttpServletResponse.SC_METHOD_NOT_ALLOWED,
@@ -235,7 +242,9 @@ public class OAuth2ProxyUtilities {
 
             HttpResponse httpResp = null;
             try {
-                if (!(reqMethod.equalsIgnoreCase("POST") || reqMethod.equalsIgnoreCase("PUT"))) {
+                if (!(reqMethod.equalsIgnoreCase("POST")
+                    || reqMethod.equalsIgnoreCase("PUT")
+                    || reqMethod.equalsIgnoreCase("PATCH"))) {
                     clientBuilder.setRedirectStrategy(new DefaultRedirectStrategy());
                 }
                 final HttpClient client = clientBuilder.build();


### PR DESCRIPTION
* Allow Patch proxying to support Zoom meeting modifications.
* Fix a copy error when body is empty; can't be null.
* Add dom4j to local ivysettings copy.

Depends on:
Zimbra/zm-mailbox#1044